### PR TITLE
Fix deploy action

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,10 +3,11 @@ AllCops:
   Include:
     - "**/Gemfile"
     - "**/lib/**.rb"
+    - "**/lib/**/**.rb"
+    - "**/bin/**.rb"
     - "**/test/**.rb"
-    - "**/features/**/**.rb"
+    - "**/test/**/**.rb"
     - "**.rb"
-    - "**/producer/**.rb"
   TargetRubyVersion: 2.7
 
 #################### Layout ################################

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,11 +2,9 @@ AllCops:
   DisabledByDefault: true
   Include:
     - "**/Gemfile"
-    - "**/lib/**.rb"
-    - "**/lib/**/**.rb"
-    - "**/bin/**.rb"
-    - "**/test/**.rb"
-    - "**/test/**/**.rb"
+    - "**/lib/**/*"
+    - "**/test/**/*"
+    - "**/bin/**"
     - "**.rb"
   TargetRubyVersion: 2.7
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.0.2)
+    serverless-tools (0.0.3)
       aws-sdk-lambda
       aws-sdk-s3
       thor
@@ -11,7 +11,7 @@ GEM
   specs:
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.532.0)
+    aws-partitions (1.534.0)
     aws-sdk-core (3.122.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
@@ -20,7 +20,7 @@ GEM
     aws-sdk-kms (1.51.0)
       aws-sdk-core (~> 3, >= 3.122.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-lambda (1.71.0)
+    aws-sdk-lambda (1.73.0)
       aws-sdk-core (~> 3, >= 3.122.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-s3 (1.106.0)

--- a/lib/serverless-tools/cli.rb
+++ b/lib/serverless-tools/cli.rb
@@ -7,7 +7,7 @@ module ServerlessTools
     desc "comment", "create Github Issue comment body"
     method_option :functions, :type => :string, :aliases => "-f", :default => "{}"
     def comment
-      comment = Comment.build(options[:functions])
+      comment = Comment.new.build(options[:functions])
       puts "::set-output name=comment::#{comment}"
     end
 

--- a/lib/serverless-tools/comment.rb
+++ b/lib/serverless-tools/comment.rb
@@ -1,9 +1,14 @@
 require "json"
+require_relative "git"
 
 module ServerlessTools
   class Comment
-    def self.build(function_json)
-      lines = ["Functions updated for sha: #{ENV["GITHUB_SHA"]} %0A"]
+    def initialize(git: Git.new)
+      @git = git
+    end
+
+    def build(function_json)
+      lines = ["Functions updated for sha: #{@git.sha} %0A"]
       lines << JSON.parse(function_json).map do |function, status|
       "> **#{function}**: #{status} %0A"
       end

--- a/lib/serverless-tools/deployer/aws_lambda_config.rb
+++ b/lib/serverless-tools/deployer/aws_lambda_config.rb
@@ -1,13 +1,15 @@
 require "yaml"
+require_relative "../git"
 
 module ServerlessTools
   module Deployer
     class AwsLambdaConfig
       attr_reader :function_name, :s3_archive_name, :handler_file, :bucket
 
-      def initialize(filename:, function_name:)
+      def initialize(filename:, function_name:, git: Git.new)
         config_data = YAML.load_file(filename)
 
+        @git = git
         @repo = config_data[function_name]["repo"]
         @function_name = function_name
         @s3_archive_name = config_data[function_name]["s3_archive_name"]
@@ -16,7 +18,7 @@ module ServerlessTools
       end
 
       def s3_key
-        "#{repo}/deployments/#{git_sha}/#{function_name}/#{s3_archive_name}"
+        "#{repo}/deployments/#{git.sha}/#{function_name}/#{s3_archive_name}"
       end
 
       def local_filename
@@ -25,11 +27,7 @@ module ServerlessTools
 
       private
 
-      attr_reader :repo
-
-      def git_sha
-        (`git rev-parse HEAD`).strip
-      end
+      attr_reader :repo, :git
     end
   end
 end

--- a/lib/serverless-tools/deployer/aws_lambda_config.rb
+++ b/lib/serverless-tools/deployer/aws_lambda_config.rb
@@ -28,7 +28,7 @@ module ServerlessTools
       attr_reader :repo
 
       def git_sha
-        (ENV["GITHUB_SHA"] || (`git rev-parse HEAD`)).strip
+        (`git rev-parse HEAD`).strip
       end
     end
   end

--- a/lib/serverless-tools/deployer/aws_lambda_function.rb
+++ b/lib/serverless-tools/deployer/aws_lambda_function.rb
@@ -9,7 +9,6 @@ module ServerlessTools
       end
 
       def update_code(object)
-        puts ""
         unless object.exists?
           puts "::warning:: Not updating #{config.function_name} as key does not exist!"
           puts "::warning:: key: #{object.key}"
@@ -20,15 +19,10 @@ module ServerlessTools
           s3_bucket: object.bucket.name,
           s3_key: object.key,
         })
-        puts "::set-output name=#{resp[:function_name]}::#{resp[:last_update_status]}"
-
-        puts "\\`#{resp[:function_name]}\\` function update was #{resp[:last_update_status]}"
-        puts "> updated with #{object.key}"
+        puts "::set-output name=#{resp[:function_name]}_status::#{resp[:last_update_status]}"
+        puts "::set-output name=#{resp[:function_name]}_key::#{object.key}"
       rescue Aws::Lambda::Errors::ServiceError => e
         puts "::error:: An error occured when updating #{config.function_name} #{e.message}"
-        puts "An error occured when updating \\`#{config.function_name}\\`"
-        puts "> attempted to update with #{object.key}"
-        puts "> error message: #{e.message}"
       end
 
       private

--- a/lib/serverless-tools/git.rb
+++ b/lib/serverless-tools/git.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+module ServerlessTools
+  class Git
+    def sha
+      (`git rev-parse HEAD`).strip
+    end
+  end
+end

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,3 +1,3 @@
 module ServerlessTools
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end

--- a/serverless-tools.gemspec
+++ b/serverless-tools.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = ["serverless-tools"]
   spec.require_paths = ["lib"]
 
-  spec.requirements << "zip"
+  spec.requirements = ["zip", "git"]
 
   spec.post_install_message = "Serverless tools, and beyond!"
 

--- a/test/comment_test.rb
+++ b/test/comment_test.rb
@@ -1,0 +1,31 @@
+require "minitest/autorun"
+require "mocha/minitest"
+
+require "serverless-tools/comment"
+
+describe "Comment" do
+  let(:git) { mock() }
+  let(:key) { "/key/to/s3/object/function.zip" }
+  let(:function) { "example_function" }
+  let(:function_json) do
+    {
+      example_function_status: "Succeeded",
+      example_function_key: key,
+    }.to_json
+  end
+
+  describe "#build" do
+    before do
+      git.stubs(:sha).returns("123")
+    end
+
+    it "returns a value" do
+      comment = ServerlessTools::Comment.new(git: git)
+
+      expected_result = "Functions updated for sha: 123 %0A"\
+                        "> **#{function}_status**: Succeeded %0A> **#{function}_key**: #{key} %0A"
+
+      assert_equal(comment.build(function_json), expected_result)
+    end
+  end
+end

--- a/test/deployer/aws_lambda_config_test.rb
+++ b/test/deployer/aws_lambda_config_test.rb
@@ -3,10 +3,12 @@ require "mocha/minitest"
 require "serverless-tools/deployer/aws_lambda_config"
 
 describe "AwsLambdaConfig" do
+  let(:git) { mock() }
   subject do
     ServerlessTools::Deployer::AwsLambdaConfig.new(
       filename: "test/fixtures/functions.yml",
-      function_name: "example_function_one_v1"
+      function_name: "example_function_one_v1",
+      git: git,
     )
   end
 
@@ -19,9 +21,7 @@ describe "AwsLambdaConfig" do
 
   describe "#key" do
     it "generates the expected s3 key for a lambda function" do
-      # git_sha shells out to get the current sha, for this test we assume
-      # that it always gets the correct sha so we mock it out with a known value
-      subject.expects(:git_sha).returns("1234567890")
+      git.expects(:sha).returns("1234567890")
       assert_equal(
         "serverless-tools/deployments/1234567890/example_function_one_v1/function.zip",
         subject.s3_key

--- a/test/deployer/aws_lambda_function_test.rb
+++ b/test/deployer/aws_lambda_function_test.rb
@@ -45,7 +45,7 @@ describe "AwsLambdaFunction" do
       lambda_function = ServerlessTools::Deployer::AwsLambdaFunction.new(config, client: lambda_client)
 
       lambda_function.expects(:puts).with("::set-output name=#{function_name}_status::Successful")
-      lambda_function.expects(:puts).with("::set-output name=#{function_name}_key::serverless-tools/deployments/1234567890/example_function_one_v1/function.zip")
+      lambda_function.expects(:puts).with("::set-output name=#{function_name}_key::#{key}")
 
       lambda_function.update_code(object)
     end

--- a/test/deployer/aws_lambda_function_test.rb
+++ b/test/deployer/aws_lambda_function_test.rb
@@ -42,10 +42,8 @@ describe "AwsLambdaFunction" do
 
       lambda_function = ServerlessTools::Deployer::AwsLambdaFunction.new(config, client: lambda_client)
 
-      lambda_function.expects(:puts).with("")
-      lambda_function.expects(:puts).with("::set-output name=#{function_name}::Successful")
-      lambda_function.expects(:puts).with("\\`#{function_name}\\` function update was Successful")
-      lambda_function.expects(:puts).with("> updated with #{key}")
+      lambda_function.expects(:puts).with("::set-output name=#{function_name}_status::Successful")
+      lambda_function.expects(:puts).with("::set-output name=#{function_name}_key::serverless-tools/deployments/1234567890/example_function_one_v1/function.zip")
 
       lambda_function.update_code(object)
     end
@@ -57,7 +55,6 @@ describe "AwsLambdaFunction" do
 
       lambda_function = ServerlessTools::Deployer::AwsLambdaFunction.new(config, client: lambda_client)
 
-      lambda_function.expects(:puts).with("")
       lambda_function.expects(:puts).with("::warning:: Not updating #{function_name} as key does not exist!")
       lambda_function.expects(:puts).with("::warning:: key: #{key}")
 
@@ -74,11 +71,7 @@ describe "AwsLambdaFunction" do
 
         lambda_function = ServerlessTools::Deployer::AwsLambdaFunction.new(config, client: lambda_client)
 
-        lambda_function.expects(:puts).with("")
         lambda_function.expects(:puts).with("::error:: An error occured when updating #{function_name} Error")
-        lambda_function.expects(:puts).with("An error occured when updating \\`#{function_name}\\`")
-        lambda_function.expects(:puts).with("> attempted to update with #{key}")
-        lambda_function.expects(:puts).with("> error message: Error")
 
         lambda_function.update_code(object)
       end

--- a/test/deployer/aws_lambda_function_test.rb
+++ b/test/deployer/aws_lambda_function_test.rb
@@ -13,16 +13,18 @@ describe "AwsLambdaFunction" do
   let(:config) do
     ServerlessTools::Deployer::AwsLambdaConfig.new(
       filename: "test/fixtures/functions.yml",
-      function_name: function_name
+      function_name: function_name,
+      git: git,
     )
   end
 
   let(:object) { mock }
   let(:bucket) { mock }
+  let(:git) { mock }
 
   describe "#update_code" do
     before do
-      config.stubs(:git_sha).returns("1234567890")
+      git.stubs(:sha).returns("1234567890")
       object.stubs(:key).returns(config.s3_key)
       object.stubs(:bucket).returns(bucket)
       bucket.stubs(:name).returns(config.bucket)

--- a/test/deployer/deployer_test.rb
+++ b/test/deployer/deployer_test.rb
@@ -22,16 +22,22 @@ describe "Deployer" do
 
   let(:lambda_client) { Aws::Lambda::Client.new(stub_responses: true) }
 
+  let(:git) { mock() }
+
   let(:config) do
     ServerlessTools::Deployer::AwsLambdaConfig.new(
       filename: "test/fixtures/functions.yml",
-      function_name: "example_function_one_v1"
+      function_name: "example_function_one_v1",
+      git: git,
     )
+  end
+
+  before do
+    git.stubs(:sha).returns("1234567890")
   end
 
   describe "#push" do
     it "uploads file to S3 object when object doesn't exist" do
-      config.expects(:git_sha).returns("1234567890")
 
       uploader = ServerlessTools::Deployer::Deployer.new(config, s3_client: s3_object_does_not_exist,
 lambda_client: lambda_client)
@@ -75,8 +81,6 @@ lambda_client: lambda_client)
     end
 
     it "does not upload file to S3 object when object exists" do
-      config.expects(:git_sha).returns("1234567890")
-
       uploader = ServerlessTools::Deployer::Deployer.new(config, s3_client: s3_object_does_exist,
 lambda_client: lambda_client)
       uploader.push
@@ -91,7 +95,6 @@ lambda_client: lambda_client)
 
   describe "#update" do
     it "updates lambda code if code object exists" do
-      config.expects(:git_sha).returns("1234567890")
       lambda_client
         .expects(:update_function_code)
         .with(
@@ -107,7 +110,6 @@ lambda_client: lambda_client)
     end
 
     it "does not update lambda code if code object does not exist" do
-      config.expects(:git_sha).returns("1234567890")
       lambda_client.expects(:update_function_code).never
 
       uploader = ServerlessTools::Deployer::Deployer.new(config, s3_client: s3_object_does_not_exist, lambda_client: lambda_client)

--- a/test/deployer/deployer_test.rb
+++ b/test/deployer/deployer_test.rb
@@ -112,7 +112,11 @@ lambda_client: lambda_client)
     it "does not update lambda code if code object does not exist" do
       lambda_client.expects(:update_function_code).never
 
-      uploader = ServerlessTools::Deployer::Deployer.new(config, s3_client: s3_object_does_not_exist, lambda_client: lambda_client)
+      uploader = ServerlessTools::Deployer::Deployer.new(
+        config,
+        s3_client: s3_object_does_not_exist,
+        lambda_client: lambda_client
+      )
       uploader.update
     end
   end

--- a/test/git_test.rb
+++ b/test/git_test.rb
@@ -1,0 +1,17 @@
+require "minitest/autorun"
+require "mocha/minitest"
+
+require "serverless-tools/git"
+
+describe "Git" do
+  describe "#sha" do
+    it "returns a value" do
+      git = ServerlessTools::Git.new
+
+      # This will call the git client so we're just checking that
+      # something is returned.
+      assert git.sha != nil
+      assert git.sha.class.name == "String"
+    end
+  end
+end


### PR DESCRIPTION
Removes the use of GITHUB_SHA which caused issues depending on which Github Workflow trigger (push vs issue_comment). The comment and deployer now use a shared code path and we'll now output the S3 key to help spot when the sha's aren't aligning easier.

There's another follow-up to potentially make the comment format nicer _and_ pull the lambda config to check wait until the status is either `Successful` or `Failed` but they are separate issues/enhancements.