### PR TITLE
Enables forcing a deployment without a new commit.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.4.3)
+    serverless-tools (0.5.0)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3
@@ -12,8 +12,8 @@ GEM
   specs:
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.576.0)
-    aws-sdk-core (3.130.1)
+    aws-partitions (1.584.0)
+    aws-sdk-core (3.130.2)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
       aws-sigv4 (~> 1.1)
@@ -31,7 +31,7 @@ GEM
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.4)
-    aws-sigv4 (1.4.0)
+    aws-sigv4 (1.5.0)
       aws-eventstream (~> 1, >= 1.0.2)
     jmespath (1.6.1)
     minitest (5.15.0)

--- a/lib/serverless-tools/cli.rb
+++ b/lib/serverless-tools/cli.rb
@@ -13,9 +13,10 @@ module ServerlessTools
     end
 
     desc "deploy", "publishes and deploys the specified lambda functions"
-    method_option :filename, :type => :string, :aliases => "-f"
+    method_option :filename, :type => :string, :aliases => "-f", :default => "functions.yml"
+    method_option :force, :type => :boolean, :aliases => "-x", :default => false
     def deploy(action, function=nil)
-      Deployer.deploy(action: action, function: function, filename: options[:filename])
+      Deployer.deploy(action: action, function: function, options: options)
     end
 
     desc "version", "prints the version of the library"

--- a/lib/serverless-tools/cli.rb
+++ b/lib/serverless-tools/cli.rb
@@ -1,6 +1,7 @@
 require "thor"
 require_relative "./comment"
 require_relative "./deployer"
+require_relative "./deployer/options"
 require_relative "./version"
 
 module ServerlessTools
@@ -16,7 +17,11 @@ module ServerlessTools
     method_option :filename, :type => :string, :aliases => "-f", :default => "functions.yml"
     method_option :force, :type => :boolean, :aliases => "-x", :default => false
     def deploy(action, function=nil)
-      Deployer.deploy(action: action, function: function, options: options)
+      Deployer.deploy(
+        action: action,
+        function: function,
+        options: Deployer::Options.new(**options)
+      )
     end
 
     desc "version", "prints the version of the library"

--- a/lib/serverless-tools/deployer.rb
+++ b/lib/serverless-tools/deployer.rb
@@ -2,22 +2,22 @@ require "yaml"
 
 require_relative "./deployer/function_deployer"
 require_relative "./deployer/yaml_config_loader"
-require_relative "./deployer/overrides"
+require_relative "./deployer/options"
 
 module ServerlessTools
   module Deployer
     def self.deploy(action:, function: nil, options: { filename: "functions.yml", force: false })
       raise "Expected to receive action but action was empty" if action.nil? || action.empty?
 
-      overrides = Overrides.new(**options)
-      config_loader = YamlConfigLoader.new(filename: overrides.filename)
+      options = Options.new(**options)
+      config_loader = YamlConfigLoader.new(filename: options.filename)
 
       lambdas_to_deploy = function ? [function] : config_loader.functions
 
       deployers = lambdas_to_deploy.map do |function_name|
         FunctionDeployer.create_for_function(
           config: config_loader.lambda_config(function_name: function_name),
-          overrides: overrides,
+          options: options,
         )
       end
 

--- a/lib/serverless-tools/deployer.rb
+++ b/lib/serverless-tools/deployer.rb
@@ -2,14 +2,12 @@ require "yaml"
 
 require_relative "./deployer/function_deployer"
 require_relative "./deployer/yaml_config_loader"
-require_relative "./deployer/options"
 
 module ServerlessTools
   module Deployer
-    def self.deploy(action:, function: nil, options: { filename: "functions.yml", force: false })
+    def self.deploy(action:, options:, function: nil)
       raise "Expected to receive action but action was empty" if action.nil? || action.empty?
 
-      options = Options.new(**options)
       config_loader = YamlConfigLoader.new(filename: options.filename)
 
       lambdas_to_deploy = function ? [function] : config_loader.functions

--- a/lib/serverless-tools/deployer/ecr_pusher.rb
+++ b/lib/serverless-tools/deployer/ecr_pusher.rb
@@ -10,23 +10,23 @@ module ServerlessTools
       end
 
       def push(local_image_name:)
-        if image_tags.include?(tag)
-          puts "Did not upload #{tagged_image_uri} as it already exists!"
-        else
-          system("docker tag #{local_image_name} #{tagged_image_uri}")
-          system("docker push #{tagged_image_uri}")
-        end
-        output
+        system("docker tag #{local_image_name} #{tagged_image_uri}")
+        system("docker push #{tagged_image_uri}")
+        asset
       end
 
       def output
         return {} unless image_tags.include?(tag)
+        asset
+      end
+
+      private
+
+      def asset
         {
           image_uri: tagged_image_uri,
         }
       end
-
-      private
 
       def image_tags
         client.describe_images(repository_name: config.repo).image_details.flat_map(&:image_tags)

--- a/lib/serverless-tools/deployer/function_deployer.rb
+++ b/lib/serverless-tools/deployer/function_deployer.rb
@@ -12,6 +12,7 @@ require_relative "./ruby_builder"
 require_relative "./docker_builder"
 require_relative "./python_builder"
 require_relative "./errors"
+require_relative "./overrides"
 
 module ServerlessTools
   module Deployer
@@ -42,16 +43,16 @@ module ServerlessTools
         update
       end
 
-      def self.create_for_function(config:)
-        send("#{config.runtime}_deployer", config)
+      def self.create_for_function(config:, overrides: Overrides.new)
+        send("#{config.runtime}_deployer", config, overrides)
       rescue NoMethodError
         raise RuntimeNotSupported.new(config: config)
       end
 
-      def self.ruby_deployer(config)
+      def self.ruby_deployer(config, overrides)
         self.new(
           builder: RubyBuilder.new(config: config),
-          pusher: S3Pusher.new(client: Aws::S3::Client.new, git: Git.new, config: config),
+          pusher: S3Pusher.new(client: Aws::S3::Client.new, git: Git.new, config: config, overrides: overrides),
           updater: LambdaUpdater.new(client: Aws::Lambda::Client.new, config: config)
         )
       end

--- a/lib/serverless-tools/deployer/function_deployer.rb
+++ b/lib/serverless-tools/deployer/function_deployer.rb
@@ -12,7 +12,6 @@ require_relative "./ruby_builder"
 require_relative "./docker_builder"
 require_relative "./python_builder"
 require_relative "./errors"
-require_relative "./options"
 
 module ServerlessTools
   module Deployer
@@ -56,7 +55,7 @@ module ServerlessTools
         pusher.output.empty?
       end
 
-      def self.create_for_function(config:, options: Options.new)
+      def self.create_for_function(config:, options:)
         send("#{config.runtime}_deployer", config, options)
       rescue NoMethodError
         raise RuntimeNotSupported.new(config: config)

--- a/lib/serverless-tools/deployer/function_deployer.rb
+++ b/lib/serverless-tools/deployer/function_deployer.rb
@@ -17,13 +17,14 @@ require_relative "./options"
 module ServerlessTools
   module Deployer
     class FunctionDeployer
-      attr_reader :builder, :pusher, :updater, :options
+      attr_reader :builder, :pusher, :updater, :options, :config
 
-      def initialize(builder:, pusher:, updater:, options:)
+      def initialize(builder:, pusher:, updater:, options:, config:)
         @builder = builder
         @pusher = pusher
         @updater = updater
         @options = options
+        @config = config
       end
 
       def build
@@ -31,7 +32,11 @@ module ServerlessTools
       end
 
       def push
-        pusher.push(**builder.output) if pusher_should_push?
+        unless pusher_should_push?
+          puts("Assets for #{config.name} have not been updated")
+          return
+        end
+        pusher.push(**builder.output)
       end
 
       def update
@@ -63,6 +68,7 @@ module ServerlessTools
           pusher: S3Pusher.new(client: Aws::S3::Client.new, git: Git.new, config: config),
           updater: LambdaUpdater.new(client: Aws::Lambda::Client.new, config: config),
           options: options,
+          config: config,
         )
       end
 
@@ -72,6 +78,7 @@ module ServerlessTools
           pusher: EcrPusher.new(client: Aws::ECR::Client.new, git: Git.new, config: config),
           updater: LambdaUpdater.new(client: Aws::Lambda::Client.new, config: config),
           options: options,
+          config: config,
         )
       end
 

--- a/lib/serverless-tools/deployer/options.rb
+++ b/lib/serverless-tools/deployer/options.rb
@@ -2,7 +2,7 @@
 
 module ServerlessTools
   module Deployer
-    Overrides = Struct.new(:force, :filename, keyword_init: true) do
+    Options = Struct.new(:force, :filename, keyword_init: true) do
       def force?
         !!force
       end

--- a/lib/serverless-tools/deployer/overrides.rb
+++ b/lib/serverless-tools/deployer/overrides.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module ServerlessTools
+  module Deployer
+    Overrides = Struct.new(:force, :filename, keyword_init: true) do
+      def force?
+        !!force
+      end
+    end
+  end
+end

--- a/lib/serverless-tools/deployer/s3_pusher.rb
+++ b/lib/serverless-tools/deployer/s3_pusher.rb
@@ -1,18 +1,20 @@
 # frozen_string_literal: true
 
 require "aws-sdk-s3"
+require_relative "./overrides"
 
 module ServerlessTools
   module Deployer
     class S3Pusher
-      def initialize(client:, git:, config:)
+      def initialize(client:, git:, config:, overrides: Overrides.new)
         @client = client
         @git = git
         @config = config
+        @overrides = overrides
       end
 
       def push(local_filename:)
-        if object.exists?
+        unless overrides.force? || !object.exists?
           puts "Did not upload #{object.key} as it already exists!"
         else
           object.upload_file(local_filename)
@@ -42,7 +44,7 @@ module ServerlessTools
         "#{config.repo}/deployments/#{git.sha}/#{config.name}/#{config.s3_archive_name}"
       end
 
-      attr_reader :client, :git, :config
+      attr_reader :client, :git, :config, :overrides
     end
   end
 end

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,3 +1,3 @@
 module ServerlessTools
-  VERSION = "0.4.3"
+  VERSION = "0.5.0"
 end

--- a/serverless-tools.gemspec
+++ b/serverless-tools.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = ["serverless-tools"]
   spec.require_paths = ["lib"]
 
-  spec.requirements = ["zip", "git", "docker"]
+  spec.requirements = ["zip", "git", "docker", "python3", "poetry", "bundle"]
 
   spec.post_install_message = "Serverless tools, and beyond!"
 

--- a/test/deployer/function_deployer_test.rb
+++ b/test/deployer/function_deployer_test.rb
@@ -122,7 +122,7 @@ module ServerlessTools::Deployer
         end
 
         it "returns a deployer with a pusher, updater, and builder" do
-          result = FunctionDeployer.create_for_function(config: ruby_config)
+          result = FunctionDeployer.create_for_function(config: ruby_config, options: options)
 
           assert_equal(result.class.name, "ServerlessTools::Deployer::FunctionDeployer")
           assert_equal(result.pusher.class.name, "ServerlessTools::Deployer::S3Pusher")
@@ -140,7 +140,7 @@ module ServerlessTools::Deployer
         end
 
         it "returns a deployer with a pusher, updater, and builder" do
-          result = FunctionDeployer.create_for_function(config: docker_config)
+          result = FunctionDeployer.create_for_function(config: docker_config, options: options)
 
           assert_equal(result.class.name, "ServerlessTools::Deployer::FunctionDeployer")
           assert_equal(result.pusher.class.name, "ServerlessTools::Deployer::EcrPusher")
@@ -156,7 +156,7 @@ module ServerlessTools::Deployer
 
         it "raises a RuntimeNotSupported error" do
           assert_raises(RuntimeNotSupported) do
-            FunctionDeployer.create_for_function(config: config)
+            FunctionDeployer.create_for_function(config: config, options: options)
           end
         end
       end

--- a/test/deployer/function_deployer_test.rb
+++ b/test/deployer/function_deployer_test.rb
@@ -27,7 +27,17 @@ module ServerlessTools::Deployer
     let(:options) { Options.new }
 
     subject do
-      FunctionDeployer.new(pusher: pusher, updater: updater, builder: builder, options: options)
+      FunctionDeployer.new(
+        pusher: pusher,
+        updater: updater,
+        builder: builder,
+        options: options,
+        config: config,
+      )
+    end
+
+    before do
+      subject.stubs(:puts)
     end
 
     describe "#deploy" do
@@ -63,11 +73,19 @@ module ServerlessTools::Deployer
       end
 
       describe "when the pusher has already pushed the asset" do
-        it "does not call push" do
+        before do
           pusher.expects(:output).returns({ s3_bucket: "test", s3_key: "test" })
+        end
 
+        it "does not call push" do
           builder.expects(:output).times(0)
           pusher.expects(:push).times(0)
+
+          subject.push
+        end
+
+        it "logs to let the user know the assets have not been pushed" do
+          subject.expects(:puts).with("Assets for example_function_one_v1 have not been updated")
 
           subject.push
         end

--- a/test/deployer/function_deployer_test.rb
+++ b/test/deployer/function_deployer_test.rb
@@ -3,7 +3,7 @@ require "mocha/minitest"
 
 require "serverless-tools/deployer/function_deployer"
 require "serverless-tools/deployer/function_config"
-require "serverless-tools/deployer/overrides"
+require "serverless-tools/deployer/options"
 require "serverless-tools/deployer/errors"
 
 module ServerlessTools::Deployer
@@ -24,10 +24,10 @@ module ServerlessTools::Deployer
       )
     end
 
-    let(:overrides) { Overrides.new }
+    let(:options) { Options.new }
 
     subject do
-      FunctionDeployer.new(pusher: pusher, updater: updater, builder: builder, overrides: overrides)
+      FunctionDeployer.new(pusher: pusher, updater: updater, builder: builder, options: options)
     end
 
     describe "#deploy" do
@@ -74,7 +74,7 @@ module ServerlessTools::Deployer
       end
 
       describe "when the force option is present" do
-        let(:overrides) { Overrides.new(force: true) }
+        let(:options) { Options.new(force: true) }
         it "will call push" do
           builder.expects(:output).returns({ local_filename: key })
           pusher.expects(:push).with(local_filename: key)

--- a/test/deployer/overrides_test.rb
+++ b/test/deployer/overrides_test.rb
@@ -1,0 +1,33 @@
+require "minitest/autorun"
+require "mocha/minitest"
+require "serverless-tools/deployer/overrides"
+
+module ServerlessTools
+  module Deployer
+    describe "Overrides" do
+      describe "by default" do
+        subject { Overrides.new() }
+
+        it "force? equals false" do
+          assert_equal(subject.force?, false)
+        end
+      end
+
+      describe "when provided with a truthy force option" do
+        subject { Overrides.new(force: true) }
+
+        it "force? equals true" do
+          assert_equal(subject.force?, true)
+        end
+      end
+
+      describe "when provided with a falsey force option" do
+        subject { Overrides.new(force: false) }
+
+        it "force? equals false" do
+          assert_equal(subject.force?, false)
+        end
+      end
+    end
+  end
+end

--- a/test/deployer/overrides_test.rb
+++ b/test/deployer/overrides_test.rb
@@ -1,12 +1,12 @@
 require "minitest/autorun"
 require "mocha/minitest"
-require "serverless-tools/deployer/overrides"
+require "serverless-tools/deployer/options"
 
 module ServerlessTools
   module Deployer
-    describe "Overrides" do
+    describe "Options" do
       describe "by default" do
-        subject { Overrides.new() }
+        subject { Options.new() }
 
         it "force? equals false" do
           assert_equal(subject.force?, false)
@@ -14,7 +14,7 @@ module ServerlessTools
       end
 
       describe "when provided with a truthy force option" do
-        subject { Overrides.new(force: true) }
+        subject { Options.new(force: true) }
 
         it "force? equals true" do
           assert_equal(subject.force?, true)
@@ -22,7 +22,7 @@ module ServerlessTools
       end
 
       describe "when provided with a falsey force option" do
-        subject { Overrides.new(force: false) }
+        subject { Options.new(force: false) }
 
         it "force? equals false" do
           assert_equal(subject.force?, false)

--- a/test/deployer/s3_pusher_test.rb
+++ b/test/deployer/s3_pusher_test.rb
@@ -27,20 +27,20 @@ module ServerlessTools::Deployer
       git.stubs(:sha).returns("1234567890")
     end
 
-    describe "when an object doesn't exist" do
-      describe "#push" do
-        before do
-          Aws::S3::Object.any_instance.stubs(:exists?).returns(false, true)
-          Aws::S3::Object.any_instance.expects(:upload_file).with("filename.zip")
-        end
-
-        it "uploads the file and returns the uploaded configuration" do
-          result = subject.push(local_filename: local_filename)
-          assert_equal(result, expected)
-        end
+    describe "#push" do
+      before do
+        Aws::S3::Object.any_instance.stubs(:exists?).returns(false, true)
+        Aws::S3::Object.any_instance.expects(:upload_file).with("filename.zip")
       end
 
-      describe "#output" do
+      it "uploads the file and returns the uploaded configuration" do
+        result = subject.push(local_filename: local_filename)
+        assert_equal(result, expected)
+      end
+    end
+
+    describe "#output" do
+      describe "when an object does not exist" do
         before do
           Aws::S3::Object.any_instance.stubs(:exists?).returns(false)
         end
@@ -49,36 +49,8 @@ module ServerlessTools::Deployer
           assert_equal(result, {})
         end
       end
-    end
 
-    describe "when an object does exist" do
-      describe "#push" do
-        before do
-          Aws::S3::Object.any_instance.stubs(:exists?).returns(true)
-          Aws::S3::Object.any_instance.expects(:upload_file).never
-        end
-
-        it "does not upload a file to S3 and returns the configuration" do
-          result = subject.push(local_filename: local_filename)
-          assert_equal(result, expected)
-        end
-
-        describe "when the force options in the overrides is true" do
-          subject { S3Pusher.new(client: s3, git: git, config: config, overrides: Overrides.new(force: true)) }
-
-          before do
-            Aws::S3::Object.any_instance.expects(:exists?).returns(true)
-            Aws::S3::Object.any_instance.expects(:upload_file).with("filename.zip")
-          end
-
-          it "uploads the file and returns the uploaded configuration" do
-            result = subject.push(local_filename: local_filename)
-            assert_equal(result, expected)
-          end
-        end
-      end
-
-      describe "#output" do
+      describe "when an object does exist" do
         before do
           Aws::S3::Object.any_instance.stubs(:exists?).returns(true)
         end

--- a/test/deployer_test.rb
+++ b/test/deployer_test.rb
@@ -26,36 +26,7 @@ module ServerlessTools
       end
 
       it "sends the action to the created deployer" do
-        Deployer.deploy(action: "build", function: function)
-      end
-
-      describe "when specifying a force" do
-        let(:options) { Deployer::Options.new(force: true, filename: filename) }
-
-        before do
-          Deployer::Options.stubs(:new)
-            .with(force: true, filename: filename)
-            .returns(options)
-        end
-
-        it "creates the correct options" do
-          Deployer.deploy(action: "build", function: function, options: { force: true, filename: filename })
-        end
-      end
-
-      describe "when specifying a different config file" do
-        let(:filename) { "dev.functions.yml" }
-        let(:options) { Deployer::Options.new(filename: filename) }
-
-        before do
-          Deployer::Options.stubs(:new)
-            .with(filename: filename)
-            .returns(options)
-        end
-
-        it "loads the correct file" do
-          Deployer.deploy(action: "build", function: function, options: { filename: filename })
-        end
+        Deployer.deploy(action: "build", function: function, options: options)
       end
     end
   end

--- a/test/deployer_test.rb
+++ b/test/deployer_test.rb
@@ -7,6 +7,9 @@ module ServerlessTools
   describe "Deployer" do
     let(:deployer) { mock() }
     let(:config) { mock() }
+    let(:lambda_config) { mock() }
+
+    let(:overrides) { Deployer::Overrides.new(filename: "functions.yml", force: false) }
 
     let(:function) { "example_function_one_v1" }
     let(:filename) { "functions.yml" }
@@ -15,9 +18,10 @@ module ServerlessTools
     describe "#deployer" do
       before do
         Deployer::YamlConfigLoader.stubs(:new).with(filename: filename).returns(config)
-        Deployer::FunctionDeployer.stubs(:create_for_function).returns(deployer)
+        Deployer::FunctionDeployer.stubs(:create_for_function).with(config: lambda_config, 
+overrides: overrides).returns(deployer)
 
-        config.expects(:lambda_config).with(function_name: function)
+        config.expects(:lambda_config).with(function_name: function).returns(lambda_config)
         deployer.expects(:build)
       end
 
@@ -25,11 +29,32 @@ module ServerlessTools
         Deployer.deploy(action: "build", function: function)
       end
 
+      describe "when specifying a force" do
+        let(:overrides) { Deployer::Overrides.new(force: true, filename: filename) }
+
+        before do
+          Deployer::Overrides.stubs(:new)
+            .with(force: true, filename: filename)
+            .returns(overrides)
+        end
+
+        it "creates the correct overrides" do
+          Deployer.deploy(action: "build", function: function, options: { force: true, filename: filename })
+        end
+      end
+
       describe "when specifying a different config file" do
         let(:filename) { "dev.functions.yml" }
+        let(:overrides) { Deployer::Overrides.new(filename: filename) }
+
+        before do
+          Deployer::Overrides.stubs(:new)
+            .with(filename: filename)
+            .returns(overrides)
+        end
 
         it "loads the correct file" do
-          Deployer.deploy(action: "build", function: function, filename: filename)
+          Deployer.deploy(action: "build", function: function, options: { filename: filename })
         end
       end
     end

--- a/test/deployer_test.rb
+++ b/test/deployer_test.rb
@@ -9,7 +9,7 @@ module ServerlessTools
     let(:config) { mock() }
     let(:lambda_config) { mock() }
 
-    let(:overrides) { Deployer::Overrides.new(filename: "functions.yml", force: false) }
+    let(:options) { Deployer::Options.new(filename: "functions.yml", force: false) }
 
     let(:function) { "example_function_one_v1" }
     let(:filename) { "functions.yml" }
@@ -18,8 +18,8 @@ module ServerlessTools
     describe "#deployer" do
       before do
         Deployer::YamlConfigLoader.stubs(:new).with(filename: filename).returns(config)
-        Deployer::FunctionDeployer.stubs(:create_for_function).with(config: lambda_config, 
-overrides: overrides).returns(deployer)
+        Deployer::FunctionDeployer.stubs(:create_for_function).with(config: lambda_config,
+          options: options).returns(deployer)
 
         config.expects(:lambda_config).with(function_name: function).returns(lambda_config)
         deployer.expects(:build)
@@ -30,27 +30,27 @@ overrides: overrides).returns(deployer)
       end
 
       describe "when specifying a force" do
-        let(:overrides) { Deployer::Overrides.new(force: true, filename: filename) }
+        let(:options) { Deployer::Options.new(force: true, filename: filename) }
 
         before do
-          Deployer::Overrides.stubs(:new)
+          Deployer::Options.stubs(:new)
             .with(force: true, filename: filename)
-            .returns(overrides)
+            .returns(options)
         end
 
-        it "creates the correct overrides" do
+        it "creates the correct options" do
           Deployer.deploy(action: "build", function: function, options: { force: true, filename: filename })
         end
       end
 
       describe "when specifying a different config file" do
         let(:filename) { "dev.functions.yml" }
-        let(:overrides) { Deployer::Overrides.new(filename: filename) }
+        let(:options) { Deployer::Options.new(filename: filename) }
 
         before do
-          Deployer::Overrides.stubs(:new)
+          Deployer::Options.stubs(:new)
             .with(filename: filename)
-            .returns(overrides)
+            .returns(options)
         end
 
         it "loads the correct file" do


### PR DESCRIPTION
This behaviour is 'dangerous' as it overwrites the previous
deployments code. But is useful for development when iterating
where you may not want to commit your changes.

Also relies on the Thor CLI defaults to populate the overrides
to allow us to handle less.

closes https://github.com/fac/serverless-tools/issues/12