### PR TITLE
Install python project dependencies from poetry build

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.4.1)
+    serverless-tools (0.4.2)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3

--- a/lib/serverless-tools/deployer/python_builder.rb
+++ b/lib/serverless-tools/deployer/python_builder.rb
@@ -9,14 +9,11 @@ module ServerlessTools
       # Run three commands to build the python bundle for Lambda
       def build
         # Poetry does not have an option to install dependencies to a specified target folder.
-        # Workaround is generating a requirments.txt file using poetry
-        `poetry export -f requirements.txt --without-hashes > requirements.txt`
-        # And then installing them using pip to specified "lambda-package" target directory
-        `pip install -r requirements.txt -t lambda-package`
-        # Zipping contents of functions and lambda-package folders with the
-        # handler file in a zip as required by AWS
+        `poetry build`
+        # Workaround is installing them using pip to specified "lambda-package" target directory
+        `python -m pip install -t lambda-package dist/*.whl`
+        # Zipping lambda-package folder with the handler file in a zip as required by AWS
         `zip -jr "#{local_filename}" #{config.handler_file}`
-        `zip -r "#{local_filename}" src`
         `cd lambda-package && zip -r "../#{local_filename}" ./*`
       end
 

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,3 +1,3 @@
 module ServerlessTools
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
 end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # a python project file structure
 [tool.poetry]
 name = "serverless-tools"
-version = "0.4.1"
+version = "0.4.2"
 description = "FreeAgent Serverless Tools"
 authors = ["yasser.bennani@freeagent.com"]
 


### PR DESCRIPTION
- Install python project dependencies from poetry build instead of using exported requirements.txt for more robust support of poetry python projects
- Bump serverless-tools version to 0.4.2