### PR TITLE
Fix docker image python errors and bump gem version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.4.2)
+    serverless-tools (0.4.3)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3

--- a/lib/serverless-tools/deployer/python_builder.rb
+++ b/lib/serverless-tools/deployer/python_builder.rb
@@ -12,7 +12,7 @@ module ServerlessTools
         # Poetry does not have an option to install dependencies to a specified target folder.
         `poetry build`
         # Workaround is installing them using pip to specified "lambda-package" target directory
-        `python -m pip install -t lambda-package dist/*.whl`
+        `python3 -m pip install -t lambda-package dist/*.whl`
         # Zipping lambda-package folder with the handler file in a zip as required by AWS
         `zip -jr "#{local_filename}" #{config.handler_file}`
         `cd lambda-package && zip -r "../#{local_filename}" ./*`

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,3 +1,3 @@
 module ServerlessTools
-  VERSION = "0.4.2"
+  VERSION = "0.4.3"
 end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # a python project file structure
 [tool.poetry]
 name = "serverless-tools"
-version = "0.4.2"
+version = "0.4.3"
 description = "FreeAgent Serverless Tools"
 authors = ["Yasser Bennani <yasser.bennani@freeagent.com>"]
 packages = [{include = 'test_package', from = "test/fixtures/test-python-project/src"}]


### PR DESCRIPTION
Fix docker image python errors causing the python bundles not being built correctly and bump gem version to 0.4.3.