### PR TITLE
Ux improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,6 @@ COPY . .
 
 RUN bundle install
 RUN bundle exec rake install
-RUN echo $(gem env)
-RUN echo $(gem list)
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.5.2)
+    serverless-tools (0.6.0)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.5.1)
+    serverless-tools (0.5.2)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3

--- a/README.md
+++ b/README.md
@@ -131,13 +131,15 @@ To execute the image locally run:
 
 You can run the image to mimic the way it would be ran by a Github Action. For example:
 
-```aws-vault exec your-aws-profile -- docker container run -e AWS_REGION=eu-west-1 -e AWS_ACCESS_KEY_ID=AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY=AWS_SECRET_ACCESS_KEY --workdir /github/workspace -v `pwd`:/github/workspace serverless-tools:latest deploy build ```
+```aws-vault exec your-aws-profile -- docker container run -e AWS_REGION -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN -e GITHUB_ENV=/home/runner --workdir /github/workspace -v `pwd`:/github/workspace serverless-tools:latest deploy build ```
 
 Breaking down this command, we can see what it does:
 
 `aws-vault exec your-aws-profile -- `. The first part uses aws-vault to assume an IAM role, and then this assumed role will be accessible when executing the next part of the command. To run any of the `deploy` commands, we need access to AWS. AWS Vault works by populating environments for the next part of the command.
 
-`docker container run -e AWS_REGION=eu-west-1 -e AWS_ACCESS_KEY_ID=AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY=AWS_SECRET_ACCESS_KEY`. We begin the call to `docker container run` and populate the environment variables of the container from the variables AWS Vault has populated.
+`docker container run -e AWS_REGION -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN`. We begin the call to `docker container run` and populate the environment variables of the container from the variables AWS Vault has populated.
+
+`-e GITHUB_ENV=/home/runner` Set the GITHUB_ENV env var to a 'realistic value'. Ordinarily, This value changes on each run, but indicates that the CLI is running inside a Github Action and is used to format the output accordingly. For more infomation see [here.](https://docs.github.com/en/actions/learn-github-actions/environment-variables)
 
 ``--workdir /github/workspace``. We're now telling the run command that the working directory will be `github/workspace` - this can be any directory, we're just using the same namespace for parity with the Github Action. Essentially the command which is executed will be from within the working directory inside the container.
 

--- a/lib/serverless-tools/deployer/function_deployer.rb
+++ b/lib/serverless-tools/deployer/function_deployer.rb
@@ -28,21 +28,29 @@ module ServerlessTools
 
       def build
         builder.build
+        puts "    📦 Assets built"
       end
 
       def push
         unless pusher_should_push?
-          puts("Assets for #{config.name} have not been updated")
+          puts("    🛑 Assets have not been updated")
           return
         end
         pusher.push(**builder.output)
+        puts "    ⬆️  Assets pushed"
       end
 
       def update
-        updater.update(pusher.output)
+        success = updater.update(pusher.output)
+        if success
+          puts "    ✅ Sucessfully updated"
+        else
+          puts "    ❌ Failed to update"
+        end
       end
 
       def deploy
+        puts "🚢 Deploying #{config.name}..."
         build
         push
         update

--- a/lib/serverless-tools/deployer/lambda_updater.rb
+++ b/lib/serverless-tools/deployer/lambda_updater.rb
@@ -13,26 +13,15 @@ module ServerlessTools
 
         response = client.update_function_code(options)
 
-        success = client.wait_until(:function_updated,
+        client.wait_until(:function_updated,
           { function_name: response[:function_name] },
           { max_attempts: 10, delay: 3 }
         )
 
-        log_output(options: options, success: success)
-
-        success
-      rescue Aws::Lambda::Errors::ServiceError, Aws::Waiters::Errors => e
-        puts "::error:: An error occured when updating #{config.name} #{e.message}"
-        log_output(options: options, success: false)
-
-        false
+        options
       end
 
       private
-
-      def log_output(options:, success:)
-        puts "::set-output name=#{options[:function_name]}_status::#{success ? "Successful" : "Failed" }"
-      end
 
       attr_reader :client, :config
     end

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,3 +1,3 @@
 module ServerlessTools
-  VERSION = "0.5.1"
+  VERSION = "0.5.2"
 end

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,3 +1,3 @@
 module ServerlessTools
-  VERSION = "0.5.2"
+  VERSION = "0.6.0"
 end

--- a/test/deployer/function_deployer_test.rb
+++ b/test/deployer/function_deployer_test.rb
@@ -58,6 +58,9 @@ module ServerlessTools::Deployer
     describe "#build" do
       it "calls the build method of the builder with the config" do
         builder.expects(:build)
+
+        subject.expects(:puts).with("    📦 Assets built")
+
         subject.build
       end
     end
@@ -66,6 +69,8 @@ module ServerlessTools::Deployer
       it "calls the push method of the pusher with the config" do
         builder.expects(:output).returns({ local_filename: key })
         pusher.expects(:output).returns({})
+
+        subject.expects(:puts).with("    ⬆️  Assets pushed")
 
         pusher.expects(:push).with(local_filename: key)
 
@@ -85,7 +90,7 @@ module ServerlessTools::Deployer
         end
 
         it "logs to let the user know the assets have not been pushed" do
-          subject.expects(:puts).with("Assets for example_function_one_v1 have not been updated")
+          subject.expects(:puts).with("    🛑 Assets have not been updated")
 
           subject.push
         end
@@ -106,9 +111,23 @@ module ServerlessTools::Deployer
       it "calls the update method of the updater with the config" do
         pusher.expects(:output).returns({ s3_key: key, s3_bucket: bucket })
 
-        updater.expects(:update).with(s3_key: key, s3_bucket: bucket)
+        updater.expects(:update).with(s3_key: key, s3_bucket: bucket).returns(true)
+
+        subject.expects(:puts).with("    ✅ Sucessfully updated")
 
         subject.update
+      end
+
+      describe "when the update fails" do
+        it "logs an appropriate failed message" do
+          pusher.expects(:output).returns({ s3_key: key, s3_bucket: bucket })
+
+          updater.expects(:update).with(s3_key: key, s3_bucket: bucket).returns(false)
+
+          subject.expects(:puts).with("    ❌ Failed to update")
+
+          subject.update
+        end
       end
     end
 

--- a/test/deployer/function_deployer_test.rb
+++ b/test/deployer/function_deployer_test.rb
@@ -13,10 +13,11 @@ module ServerlessTools::Deployer
     let(:updater) { mock("updater") }
     let(:bucket) { "freeagent-lambda-example-scripts" }
     let(:key) { "function.zip" }
+    let(:function_name) { "example_function_one_v1" }
 
     let(:config) do
       FunctionConfig.new(
-        name: "example_function_one_v1",
+        name: function_name,
         bucket: bucket,
         repo: "serverless-tools",
         s3_archive_name: key,
@@ -25,6 +26,7 @@ module ServerlessTools::Deployer
     end
 
     let(:options) { Options.new }
+    let(:in_github) { "" }
 
     subject do
       FunctionDeployer.new(
@@ -33,6 +35,7 @@ module ServerlessTools::Deployer
         builder: builder,
         options: options,
         config: config,
+        in_github: in_github,
       )
     end
 
@@ -108,25 +111,58 @@ module ServerlessTools::Deployer
     end
 
     describe "#update" do
-      it "calls the update method of the updater with the config" do
-        pusher.expects(:output).returns({ s3_key: key, s3_bucket: bucket })
+      let(:s3_config) {{ s3_key: key, s3_bucket: bucket }}
+      let(:s3_update_output) {{ **s3_config, function_name: function_name }}
 
-        updater.expects(:update).with(s3_key: key, s3_bucket: bucket).returns(true)
+      it "calls the update method of the updater with the config" do
+        pusher.expects(:output).returns(s3_config)
+
+        updater.expects(:update).with(s3_key: key, s3_bucket: bucket).returns(s3_update_output)
 
         subject.expects(:puts).with("    ✅ Sucessfully updated")
 
         subject.update
       end
 
+      describe "and the deployer is running on Github" do
+        let(:in_github) { "GITHUB_ENV" }
+        it "logs an output for github" do
+          pusher.expects(:output).returns(s3_config)
+
+          updater.expects(:update).with(s3_key: key, s3_bucket: bucket).returns(s3_update_output)
+
+          subject.expects(:puts).with("    ✅ Sucessfully updated")
+          subject.expects(:puts).with("::set-output name=#{function_name}_status::Success")
+
+          subject.update
+        end
+      end
+
       describe "when the update fails" do
         it "logs an appropriate failed message" do
           pusher.expects(:output).returns({ s3_key: key, s3_bucket: bucket })
 
-          updater.expects(:update).with(s3_key: key, s3_bucket: bucket).returns(false)
+          updater.expects(:update).with(s3_key: key, 
+s3_bucket: bucket).raises(Aws::Lambda::Errors::ServiceError.new(mock, "Test Error"))
 
           subject.expects(:puts).with("    ❌ Failed to update")
 
           subject.update
+        end
+
+        describe("and the deployer is running on Github") do
+          let(:in_github) { "GITHUB_ENV" }
+          it "logs an output error for github" do
+            pusher.expects(:output).returns({ s3_key: key, s3_bucket: bucket })
+
+            updater.expects(:update).with(s3_key: key, 
+s3_bucket: bucket).raises(Aws::Lambda::Errors::ServiceError.new(mock, "Test Error"))
+
+            subject.expects(:puts).with("    ❌ Failed to update")
+            subject.expects(:puts).with("::set-output name=#{function_name}_status::Failed")
+
+            subject.update
+          end
         end
       end
     end

--- a/test/deployer/lambda_updater_test.rb
+++ b/test/deployer/lambda_updater_test.rb
@@ -13,6 +13,9 @@ module ServerlessTools::Deployer
     let(:key) { "serverless-tools/deployments/1234567890/#{function_name}/function.zip" }
     let(:bucket) { "freeagent-lambda-example-scripts" }
 
+    let(:wait_response) { true }
+    let(:options) {{ s3_key: key, s3_bucket: bucket }}
+
     let(:config) do
       FunctionConfig.new(
         name: "example_function_one_v1",
@@ -22,23 +25,66 @@ module ServerlessTools::Deployer
       )
     end
 
+    let(:lambda_updater) { LambdaUpdater.new(client: lambda_client, config: config) }
+
+    before do
+      lambda_client
+        .expects(:update_function_code)
+        .with(
+          has_entries(
+            s3_bucket: bucket,
+            s3_key: key
+          )
+        ).returns(
+          Aws::Lambda::Types::FunctionConfiguration.new(
+            function_name: function_name,
+            last_update_status: "InProgress"
+          )
+        )
+    end
+
     describe "#update_code" do
-      it "updates lambda code" do
-        lambda_client
-          .expects(:update_function_code)
-          .with(
-            has_entries(
-              s3_bucket: bucket,
-              s3_key: key
-            )
-          ).returns({ function_name: function_name, last_update_status: "Successful" })
+      describe "when the waiter completes" do
+        before do
+          lambda_client.expects(:wait_until).with(
+            :function_updated,
+            { function_name: function_name },
+            { max_attempts: 10, delay: 3 }
+          ).returns(wait_response)
+        end
 
-        lambda_function = LambdaUpdater.new(client: lambda_client, config: config)
+        it "updates lambda code" do
+          lambda_updater.expects(:puts).with("::set-output name=#{function_name}_status::Successful")
+          response = lambda_updater.update(options)
 
-        options = { s3_key: key, s3_bucket: bucket }
-        lambda_function.expects(:puts).with("::set-output name=#{function_name}_status::Successful")
+          assert_equal(response, wait_response)
+        end
 
-        lambda_function.update(options)
+        describe "when the waiter returns false" do
+          let(:wait_response) { false }
+
+          it "sets the status output to Failed" do
+            lambda_updater.expects(:puts).with("::set-output name=#{function_name}_status::Failed")
+            response = lambda_updater.update(options)
+
+            assert_equal(response, wait_response)
+          end
+        end
+      end
+      describe "when an error is raised" do
+        it "sets the output for the function with a failed status and returns false" do
+          lambda_client.expects(:wait_until).with(
+            :function_updated,
+            { function_name: function_name },
+            { max_attempts: 10, delay: 3 }
+          ).raises(Aws::Lambda::Errors::ServiceError.new(mock, "Test Error"))
+
+          lambda_updater.expects(:puts).with("::error:: An error occured when updating #{function_name} Test Error")
+          lambda_updater.expects(:puts).with("::set-output name=#{function_name}_status::Failed")
+          response = lambda_updater.update(options)
+
+          assert_equal(response, false)
+        end
       end
     end
   end

--- a/test/deployer/lambda_updater_test.rb
+++ b/test/deployer/lambda_updater_test.rb
@@ -41,50 +41,19 @@ module ServerlessTools::Deployer
             last_update_status: "InProgress"
           )
         )
+
+      lambda_client.expects(:wait_until).with(
+        :function_updated,
+        { function_name: function_name },
+        { max_attempts: 10, delay: 3 }
+      ).returns(wait_response)
     end
 
     describe "#update_code" do
-      describe "when the waiter completes" do
-        before do
-          lambda_client.expects(:wait_until).with(
-            :function_updated,
-            { function_name: function_name },
-            { max_attempts: 10, delay: 3 }
-          ).returns(wait_response)
-        end
+      it "updates lambda code" do
+        response = lambda_updater.update(options)
 
-        it "updates lambda code" do
-          lambda_updater.expects(:puts).with("::set-output name=#{function_name}_status::Successful")
-          response = lambda_updater.update(options)
-
-          assert_equal(response, wait_response)
-        end
-
-        describe "when the waiter returns false" do
-          let(:wait_response) { false }
-
-          it "sets the status output to Failed" do
-            lambda_updater.expects(:puts).with("::set-output name=#{function_name}_status::Failed")
-            response = lambda_updater.update(options)
-
-            assert_equal(response, wait_response)
-          end
-        end
-      end
-      describe "when an error is raised" do
-        it "sets the output for the function with a failed status and returns false" do
-          lambda_client.expects(:wait_until).with(
-            :function_updated,
-            { function_name: function_name },
-            { max_attempts: 10, delay: 3 }
-          ).raises(Aws::Lambda::Errors::ServiceError.new(mock, "Test Error"))
-
-          lambda_updater.expects(:puts).with("::error:: An error occured when updating #{function_name} Test Error")
-          lambda_updater.expects(:puts).with("::set-output name=#{function_name}_status::Failed")
-          response = lambda_updater.update(options)
-
-          assert_equal(response, false)
-        end
+        assert_equal(response, { **options, function_name: function_name } )
       end
     end
   end


### PR DESCRIPTION
Closes #10 and Closes #11

The idea here is that when the CLI is ran from a 'local' device, we don't get the output required for Github Actions. The local output then gives nicer feedback when the actions are performed. As a result, we will also wait until the lambda status has 'settled' into a positive state, or raises an error if it fails to update. If an error is raised, the failure message is logged by the Function Deployer. 

As a side note, we raise where the logging is managed, so the individual lambda updater no longer worries about logging. The benefit here is that it does not care if it's running in a github action. The centeralised 'deployer' class (Function Deployer) will manage all the logging.