### PR TITLE
Add Workflow for publishing gem to FAC Gem repo

### DIFF
--- a/.github/workflows/freeagent-gem.yml
+++ b/.github/workflows/freeagent-gem.yml
@@ -1,0 +1,58 @@
+name: Gem Build and Release
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true # bundle install
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+      - name: Setup Poetry # Required for testing but not for building the gem.
+        uses: abatilo/actions-poetry@v2.1.6
+        with:
+          poetry-version: "1.1.13"
+      - run: bundle install
+      - run: bundle exec rake test
+
+  release:
+    name: Gem / Release
+    needs: test # Only release IF the tests pass
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+          bundler-cache: true
+    - uses: fac/ruby-gem-setup-credentials-action@v2
+      with:
+        token: ${{ secrets.github_token }}
+
+    - name: Build Gem
+      run: bundle exec rake build
+
+    # Release production gem version from default branch
+    - name: Release Gem
+      if:   ${{ github.ref == 'refs/heads/main' }}
+      uses: fac/ruby-gem-push-action@v2
+      with:
+        key: github
+
+    # PR branch builds will release pre-release gems
+    - name: Pre-Release Gem
+      if:   ${{ github.ref != 'refs/heads/main' }}
+      uses: fac/ruby-gem-push-action@v2
+      with:
+        key: github
+        pre-release: true

--- a/serverless-tools.gemspec
+++ b/serverless-tools.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
+    spec.metadata["allowed_push_host"] = 'https://rubygems.pkg.github.com/fac'
 
     spec.metadata["homepage_uri"] = spec.homepage
     spec.metadata["source_code_uri"] = "https://github.com/fac/serverless-tools"


### PR DESCRIPTION
This PR follow the steps outlined in notion to add this gem to our internal gems: https://www.notion.so/freeagent/GitHub-Actions-Creating-Workflows-0a65b05b8cf94ebda71ad203e04e96df#22df312d771e4996bf140255b4eb9a09

This will allow others to install the gem like other gems (and not have to clone the repo and install it locally).