### PR TITLE
Fix `set-output` in serverless-tool repo

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.6.0)
+    serverless-tools (0.7.0)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3
@@ -74,4 +74,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   2.2.32
+   2.2.33

--- a/lib/serverless-tools/cli.rb
+++ b/lib/serverless-tools/cli.rb
@@ -10,7 +10,7 @@ module ServerlessTools
     method_option :functions, :type => :string, :aliases => "-f", :default => "{}"
     def comment
       comment = Comment.new.build(options[:functions])
-      puts "::set-output name=comment::#{comment}"
+      puts("\"comment=#{comment}\" >> \"$GITHUB_OUTPUT\"")
     end
 
     desc "deploy", "publishes and deploys the specified lambda functions"

--- a/lib/serverless-tools/cli.rb
+++ b/lib/serverless-tools/cli.rb
@@ -10,7 +10,7 @@ module ServerlessTools
     method_option :functions, :type => :string, :aliases => "-f", :default => "{}"
     def comment
       comment = Comment.new.build(options[:functions])
-      puts("\"comment=#{comment}\" >> \"$GITHUB_OUTPUT\"")
+      puts("echo \"comment=#{comment}\" >> \"$GITHUB_OUTPUT\"")
     end
 
     desc "deploy", "publishes and deploys the specified lambda functions"

--- a/lib/serverless-tools/cli.rb
+++ b/lib/serverless-tools/cli.rb
@@ -10,7 +10,7 @@ module ServerlessTools
     method_option :functions, :type => :string, :aliases => "-f", :default => "{}"
     def comment
       comment = Comment.new.build(options[:functions])
-      puts("echo \"comment=#{comment}\" >> \"$GITHUB_OUTPUT\"")
+      system("echo \"comment=#{comment}\" >> \"$GITHUB_OUTPUT\"")
     end
 
     desc "deploy", "publishes and deploys the specified lambda functions"

--- a/lib/serverless-tools/deployer/function_deployer.rb
+++ b/lib/serverless-tools/deployer/function_deployer.rb
@@ -62,11 +62,11 @@ module ServerlessTools
       private
 
       def log_github_output(response)
-        puts "::set-output name=#{response[:function_name]}_status::Success"
+        puts("\"#{response[:function_name]}_status=Success\" >> \"$GITHUB_OUTPUT\"")
       end
 
       def log_github_error
-       puts("::set-output name=#{config.name}_status::Failed")
+       puts("\"#{config.name}_status=Failed\" >> \"$GITHUB_OUTPUT\"")
       end
 
       def pusher_should_push?

--- a/lib/serverless-tools/deployer/function_deployer.rb
+++ b/lib/serverless-tools/deployer/function_deployer.rb
@@ -62,11 +62,11 @@ module ServerlessTools
       private
 
       def log_github_output(response)
-        puts("echo \"#{response[:function_name]}_status=Success\" >> \"$GITHUB_OUTPUT\"")
+        system("echo \"#{response[:function_name]}_status=Success\" >> \"$GITHUB_OUTPUT\"")
       end
 
       def log_github_error
-       puts("echo \"#{config.name}_status=Failed\" >> \"$GITHUB_OUTPUT\"")
+        system("echo \"#{config.name}_status=Failed\" >> \"$GITHUB_OUTPUT\"")
       end
 
       def pusher_should_push?

--- a/lib/serverless-tools/deployer/function_deployer.rb
+++ b/lib/serverless-tools/deployer/function_deployer.rb
@@ -62,11 +62,11 @@ module ServerlessTools
       private
 
       def log_github_output(response)
-        puts("\"#{response[:function_name]}_status=Success\" >> \"$GITHUB_OUTPUT\"")
+        puts("echo \"#{response[:function_name]}_status=Success\" >> \"$GITHUB_OUTPUT\"")
       end
 
       def log_github_error
-       puts("\"#{config.name}_status=Failed\" >> \"$GITHUB_OUTPUT\"")
+       puts("echo \"#{config.name}_status=Failed\" >> \"$GITHUB_OUTPUT\"")
       end
 
       def pusher_should_push?

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,3 +1,3 @@
 module ServerlessTools
-  VERSION = "0.6.0"
+  VERSION = "0.7.0"
 end

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,3 +1,3 @@
 module ServerlessTools
-  VERSION = "0.7.0"
+  VERSION = "0.6.0"
 end

--- a/test/deployer/function_deployer_test.rb
+++ b/test/deployer/function_deployer_test.rb
@@ -132,7 +132,7 @@ module ServerlessTools::Deployer
           updater.expects(:update).with(s3_key: key, s3_bucket: bucket).returns(s3_update_output)
 
           subject.expects(:puts).with("    ✅ Sucessfully updated")
-          subject.expects(:puts).with("::set-output name=#{function_name}_status::Success")
+          subject.expects(:puts).with("\"#{function_name}_status=Success\" >> \"$GITHUB_OUTPUT\"")
 
           subject.update
         end
@@ -142,7 +142,7 @@ module ServerlessTools::Deployer
         it "logs an appropriate failed message" do
           pusher.expects(:output).returns({ s3_key: key, s3_bucket: bucket })
 
-          updater.expects(:update).with(s3_key: key, 
+          updater.expects(:update).with(s3_key: key,
 s3_bucket: bucket).raises(Aws::Lambda::Errors::ServiceError.new(mock, "Test Error"))
 
           subject.expects(:puts).with("    ❌ Failed to update")
@@ -155,11 +155,11 @@ s3_bucket: bucket).raises(Aws::Lambda::Errors::ServiceError.new(mock, "Test Erro
           it "logs an output error for github" do
             pusher.expects(:output).returns({ s3_key: key, s3_bucket: bucket })
 
-            updater.expects(:update).with(s3_key: key, 
+            updater.expects(:update).with(s3_key: key,
 s3_bucket: bucket).raises(Aws::Lambda::Errors::ServiceError.new(mock, "Test Error"))
 
             subject.expects(:puts).with("    ❌ Failed to update")
-            subject.expects(:puts).with("::set-output name=#{function_name}_status::Failed")
+            subject.expects(:puts).with("\"#{function_name}_status=Failed\" >> \"$GITHUB_OUTPUT\"")
 
             subject.update
           end

--- a/test/deployer/function_deployer_test.rb
+++ b/test/deployer/function_deployer_test.rb
@@ -132,7 +132,7 @@ module ServerlessTools::Deployer
           updater.expects(:update).with(s3_key: key, s3_bucket: bucket).returns(s3_update_output)
 
           subject.expects(:puts).with("    ✅ Sucessfully updated")
-          subject.expects(:puts).with("echo \"#{function_name}_status=Success\" >> \"$GITHUB_OUTPUT\"")
+          subject.expects(:system).with("echo \"#{function_name}_status=Success\" >> \"$GITHUB_OUTPUT\"")
 
           subject.update
         end
@@ -159,7 +159,7 @@ s3_bucket: bucket).raises(Aws::Lambda::Errors::ServiceError.new(mock, "Test Erro
 s3_bucket: bucket).raises(Aws::Lambda::Errors::ServiceError.new(mock, "Test Error"))
 
             subject.expects(:puts).with("    ❌ Failed to update")
-            subject.expects(:puts).with("echo \"#{function_name}_status=Failed\" >> \"$GITHUB_OUTPUT\"")
+            subject.expects(:system).with("echo \"#{function_name}_status=Failed\" >> \"$GITHUB_OUTPUT\"")
 
             subject.update
           end

--- a/test/deployer/function_deployer_test.rb
+++ b/test/deployer/function_deployer_test.rb
@@ -132,7 +132,7 @@ module ServerlessTools::Deployer
           updater.expects(:update).with(s3_key: key, s3_bucket: bucket).returns(s3_update_output)
 
           subject.expects(:puts).with("    ✅ Sucessfully updated")
-          subject.expects(:puts).with("\"#{function_name}_status=Success\" >> \"$GITHUB_OUTPUT\"")
+          subject.expects(:puts).with("echo \"#{function_name}_status=Success\" >> \"$GITHUB_OUTPUT\"")
 
           subject.update
         end
@@ -159,7 +159,7 @@ s3_bucket: bucket).raises(Aws::Lambda::Errors::ServiceError.new(mock, "Test Erro
 s3_bucket: bucket).raises(Aws::Lambda::Errors::ServiceError.new(mock, "Test Error"))
 
             subject.expects(:puts).with("    ❌ Failed to update")
-            subject.expects(:puts).with("\"#{function_name}_status=Failed\" >> \"$GITHUB_OUTPUT\"")
+            subject.expects(:puts).with("echo \"#{function_name}_status=Failed\" >> \"$GITHUB_OUTPUT\"")
 
             subject.update
           end


### PR DESCRIPTION
# What
- Updating the serverless tool to output the new `set-output` syntax, since the old one will be deprecated

Before:
```
echo "::set-output name=output_var::$output_string"
```

After:
```
echo "output_var=$output_string" >> "$GITHUB_OUTPUT"
```

Dev-P ticket:
- https://github.com/fac/dev-platform/issues/1271