### PR TITLE
Fix multi-line comments for function updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.7.0)
+    serverless-tools (0.7.1)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3

--- a/lib/serverless-tools/cli.rb
+++ b/lib/serverless-tools/cli.rb
@@ -9,10 +9,8 @@ module ServerlessTools
     desc "comment", "create Github Issue comment body"
     method_option :functions, :type => :string, :aliases => "-f", :default => "{}"
     def comment
-      comment = Comment.new.build(options[:functions])
-
       system("echo \"comment<<EOF\" >> $GITHUB_OUTPUT")
-      comment.map do |line|
+      Comment.new.build(options[:functions]) do |line|
         system("echo \"#{line}\" >> $GITHUB_OUTPUT")
       end
       system("echo \"EOF\" >> $GITHUB_OUTPUT")

--- a/lib/serverless-tools/cli.rb
+++ b/lib/serverless-tools/cli.rb
@@ -10,7 +10,12 @@ module ServerlessTools
     method_option :functions, :type => :string, :aliases => "-f", :default => "{}"
     def comment
       comment = Comment.new.build(options[:functions])
-      system("echo \"comment=#{comment}\" >> \"$GITHUB_OUTPUT\"")
+
+      system("echo \"comment<<EOF\" >> $GITHUB_OUTPUT")
+      comment.map do |line|
+        system("echo \"#{line}\" >> $GITHUB_OUTPUT")
+      end
+      system("echo \"EOF\" >> $GITHUB_OUTPUT")
     end
 
     desc "deploy", "publishes and deploys the specified lambda functions"

--- a/lib/serverless-tools/comment.rb
+++ b/lib/serverless-tools/comment.rb
@@ -8,11 +8,11 @@ module ServerlessTools
     end
 
     def build(function_json)
-      lines = ["Functions updated for sha: #{@git.sha} %0A"]
-      lines << JSON.parse(function_json).map do |function, status|
-      "> **#{function}**: #{status} %0A"
+      lines = ["Functions updated for sha: #{@git.sha}"]
+      JSON.parse(function_json).each do |function, status|
+        lines << "> **#{function}**: #{status}"
       end
-      lines.join
+      lines
     end
   end
 end

--- a/lib/serverless-tools/comment.rb
+++ b/lib/serverless-tools/comment.rb
@@ -12,7 +12,12 @@ module ServerlessTools
       JSON.parse(function_json).each do |function, status|
         lines << "> **#{function}**: #{status}"
       end
-      lines
+
+      if block_given?
+        lines.map { |line| yield line }
+      end
+
+      lines.join("\n")
     end
   end
 end

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,3 +1,3 @@
 module ServerlessTools
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 end

--- a/test/comment_test.rb
+++ b/test/comment_test.rb
@@ -22,8 +22,8 @@ describe "Comment" do
     it "returns a value" do
       comment = ServerlessTools::Comment.new(git: git)
 
-      expected_result = "Functions updated for sha: 123 %0A"\
-                        "> **#{function}_status**: Succeeded %0A> **#{function}_key**: #{key} %0A"
+      expected_result = ["Functions updated for sha: 123",
+"> **#{function}_status**: Succeeded", "> **#{function}_key**: #{key}"]
 
       assert_equal(comment.build(function_json), expected_result)
     end

--- a/test/comment_test.rb
+++ b/test/comment_test.rb
@@ -22,10 +22,31 @@ describe "Comment" do
     it "returns a value" do
       comment = ServerlessTools::Comment.new(git: git)
 
-      expected_result = ["Functions updated for sha: 123",
-"> **#{function}_status**: Succeeded", "> **#{function}_key**: #{key}"]
+      expected_result = <<~EOF.strip
+        Functions updated for sha: 123
+        > **#{function}_status**: Succeeded
+        > **#{function}_key**: #{key}
+      EOF
 
       assert_equal(comment.build(function_json), expected_result)
+    end
+
+    it "yields the comment line by line if given a block" do
+      comment = ServerlessTools::Comment.new(git: git)
+
+      expected_result = [
+        "Functions updated for sha: 123",
+        "> **#{function}_status**: Succeeded",
+        "> **#{function}_key**: #{key}"
+      ]
+
+      result = []
+
+      comment.build(function_json) do |line|
+        result << line
+      end
+
+      assert_equal(result, expected_result)
     end
   end
 end


### PR DESCRIPTION
## Problem

The change to use `$GITHUB_OUTPUT` instead of the deprecated `set-output` broke the formatting of multi-line comments: 

![Screenshot 2022-11-04 at 16 00 24](https://user-images.githubusercontent.com/25990431/200300974-c92822d7-7111-48c7-a96b-e34c7e77d809.png)

It looks like the `$GITHUB_OUTPUT` [interprets multi-line values differently than `set-output`](https://stackoverflow.com/questions/74137120/how-to-fix-or-avoid-error-unable-to-process-file-command-output-successfully)

## Solution
This PR changes the behaviour of the `comment` command to insert lines individually into the `$GITHUB_OUTPUT` env variable. The resulting comment looks as follows: 

![Screenshot 2022-11-07 at 11 40 35](https://user-images.githubusercontent.com/25990431/200301505-543529aa-fd85-4ddd-ab62-f7c5cc33959a.png)

Tested on[ this branch](https://github.com/fac/event-system/pull/163) in the event-system repo. 

