### PR TITLE
Enable building and pushing Docker based functions from within Docker (and GHA)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,34 @@
-FROM ruby:2.7-slim-bullseye
+FROM docker:20.10-dind
 
-RUN apt-get update -y
-RUN apt-get install -y git zip curl python3.9 python3-venv python3-pip
+RUN apk upgrade
+RUN apk update
+
+# Install Ruby
+## We're pinning this to ruby 2.7.0 as that's what Serverless tools currently supports.
+RUN apk add ruby-full=2.7.6-r0 ruby-dev=2.7.6-r0 --repository https://dl-cdn.alpinelinux.org/alpine/v3.14/main/
+
+RUN gem install bundler
+
+# Lock Python to 3.9 as that's the version used in our functions
+RUN apk add python3=3.9.15-r0 python3-dev=3.9.15-r0 --repository https://dl-cdn.alpinelinux.org/alpine/v3.14/main/
+RUN apk add libffi-dev=3.3-r2 libffi=3.3-r2 --repository https://dl-cdn.alpinelinux.org/alpine/v3.14/main/
+RUN apk add py3-pip py3-virtualenv
+RUN python3 -m ensurepip
+
+# Add in all the native dependencies we need to run bundle, poetry, and serverless-tools
+RUN apk add git curl zip aws-cli gcc pkgconfig libc-dev
+
+# Setup Poetry for Python functions
 ENV POETRY_HOME=/etc/poetry
-RUN curl -sSL https://install.python-poetry.org | python3.9 - --version 1.1.13
+RUN curl -sSL https://install.python-poetry.org | python3 - --version 1.1.13
 ENV PATH="${PATH}:/${POETRY_HOME}/bin"
 
+# Install Serverless-Tools
 COPY . .
 
+RUN bundle config set --global without 'development'
 RUN bundle install
+RUN bundle add rake
 RUN bundle exec rake install
 
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk upgrade
 RUN apk update
 
 # Install Ruby
-## We're pinning this to ruby 2.7.0 as that's what Serverless tools currently supports.
+## We're pinning this to ruby 2.7 as that's what Serverless tools currently supports.
 RUN apk add ruby-full=2.7.6-r0 ruby-dev=2.7.6-r0 --repository https://dl-cdn.alpinelinux.org/alpine/v3.14/main/
 
 RUN gem install bundler
@@ -12,11 +12,11 @@ RUN gem install bundler
 # Lock Python to 3.9 as that's the version used in our functions
 RUN apk add python3=3.9.15-r0 python3-dev=3.9.15-r0 --repository https://dl-cdn.alpinelinux.org/alpine/v3.14/main/
 RUN apk add libffi-dev=3.3-r2 libffi=3.3-r2 --repository https://dl-cdn.alpinelinux.org/alpine/v3.14/main/
-RUN apk add py3-pip py3-virtualenv
 RUN python3 -m ensurepip
+RUN pip3 install --upgrade pip setuptools virtualenv awscli
 
-# Add in all the native dependencies we need to run bundle, poetry, and serverless-tools
-RUN apk add git curl zip aws-cli gcc pkgconfig libc-dev
+# Add in all the native dependencies we need to run bundle, poetry, and serverless-tools etc.
+RUN apk add git curl zip gcc pkgconfig libc-dev
 
 # Setup Poetry for Python functions
 ENV POETRY_HOME=/etc/poetry

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.8.0)
+    serverless-tools (0.9.0)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3
@@ -12,8 +12,8 @@ GEM
   specs:
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.655.0)
-    aws-sdk-core (3.166.0)
+    aws-partitions (1.665.0)
+    aws-sdk-core (3.168.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.5)
@@ -24,7 +24,7 @@ GEM
     aws-sdk-kms (1.59.0)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-lambda (1.86.0)
+    aws-sdk-lambda (1.87.0)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-s3 (1.117.1)

--- a/lib/serverless-tools/deployer/ecr_pusher.rb
+++ b/lib/serverless-tools/deployer/ecr_pusher.rb
@@ -11,6 +11,7 @@ module ServerlessTools
 
       def push(local_image_name:)
         system("docker tag #{local_image_name} #{tagged_image_uri}")
+        system("aws ecr get-login-password | docker login --username AWS --password-stdin #{repository_uri}")
         system("docker push #{tagged_image_uri}")
         asset
       end

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,3 +1,3 @@
 module ServerlessTools
-  VERSION = "0.8.0"
+  VERSION = "0.9.0"
 end

--- a/test/deployer/ecr_pusher_test.rb
+++ b/test/deployer/ecr_pusher_test.rb
@@ -30,6 +30,9 @@ module ServerlessTools::Deployer
           "docker tag #{local_image_name} #{registry_uri}/#{repo}:#{short_sha}"
         )
         subject.expects(:system).with(
+          "aws ecr get-login-password | docker login --username AWS --password-stdin #{registry_uri}/#{repo}"
+        )
+        subject.expects(:system).with(
           "docker push #{registry_uri}/#{repo}:#{short_sha}"
         )
 


### PR DESCRIPTION
closes https://github.com/fac/serverless-tools/issues/27

Docker support has always been limited to running serverless tools locally. This change updates the Dockerfile (which can be used locally) or more commonly as a Github Action. The image now supports building and pushing Docker based functions, as well as the other runtimes (Python 3.9, Ruby2.7).

The following scenarios scenarios and context have been tested (and x indicates a passing test - e.g. deploying changes to lambda functions with those environments)

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-771eb67d-7fff-22be-b4bf-76aecb982f99"><div dir="ltr" style="margin-left:0pt;">

Runtime | Local Env (Native) | Local Env (Docker) | Github Action
-- | -- | -- | --
Docker |x|x|x| 
Ruby | x | x |x| 
Python |x|x|x| 

</div></b>

For Github Action runs I have tested the build and push steps of each runtime.
There is an issue with the permissions set on the `git` repo in the action, which the change to Alpine which requires an additional step in the action runner (after the checkout step):

```
 # This is a fix for an issue with the github runners and compatibility with git on alpine where the user doesn't have permission to run git commands within the workspace.
 # See https://github.com/actions/runner/issues/2033 for more details
- name: Fix git safe.directory in container
  run: mkdir -p /home/runner/work/_temp/_github_home && printf "[safe]\n\tdirectory = /github/workspace" > /home/runner/work/_temp/_github_home/.gitconfig
```
 
 Locally with wither the native gem or docker env, I've built, pushed and deployed successfully. 
