### PR TITLE
Always Install Correct Bundler Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV PATH="${PATH}:/${POETRY_HOME}/bin"
 
 COPY . .
 
+RUN gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)"
 RUN bundle install
 RUN bundle exec rake install
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.8.1)
+    serverless-tools (0.8.2)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3
@@ -12,8 +12,8 @@ GEM
   specs:
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.665.0)
-    aws-sdk-core (3.168.1)
+    aws-partitions (1.667.0)
+    aws-sdk-core (3.168.2)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.5)
@@ -24,7 +24,7 @@ GEM
     aws-sdk-kms (1.59.0)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-lambda (1.87.0)
+    aws-sdk-lambda (1.88.0)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-s3 (1.117.1)
@@ -33,7 +33,7 @@ GEM
       aws-sigv4 (~> 1.4)
     aws-sigv4 (1.5.2)
       aws-eventstream (~> 1, >= 1.0.2)
-    jmespath (1.6.1)
+    jmespath (1.6.2)
     json (2.6.2)
     minitest (5.16.3)
     mocha (1.16.0)
@@ -76,4 +76,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   2.3.24
+   2.3.6

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,3 +1,3 @@
 module ServerlessTools
-  VERSION = "0.8.1"
+  VERSION = "0.8.2"
 end


### PR DESCRIPTION
This updates the Dockerfile to ensure that we always install the correct version of Bundler for the Gemfile.lock before attempting to `bundle install`. This will fix issues where the `ruby:2.7-slim-bullseye` base image (that is used by the Lambda template) has an older version of `bundle` than the lockfile - causing a failure.

I got the line to fix this from the [bundler blog](https://bundler.io/blog/2019/05/14/solutions-for-cant-find-gem-bundler-with-executable-bundle.html). We should be [okay after bundler 2.3](https://bundler.io/blog/2022/01/23/bundler-v2-3.html) as it will auto-install the correct version for us.

I've tested this internally and the image successfully builds on the `ruby:2.7-slim-bullseye` base image.