### PR TITLE
Enable building and pushing Docker based functions from within Docker (and GHA)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,26 @@
 FROM ruby:2.7-slim-bullseye
 
+## Install System Dependencies
 RUN apt-get update -y
-RUN apt-get install -y git zip curl python3.9 python3-venv python3-pip
+RUN apt-get install -y git zip curl ca-certificates gnupg lsb-release python3.9 python3-venv python3-pip awscli
+
+## Setup Python
 ENV POETRY_HOME=/etc/poetry
 RUN curl -sSL https://install.python-poetry.org | python3.9 - --version 1.1.13
 ENV PATH="${PATH}:/${POETRY_HOME}/bin"
 
+## Setup Docker https://docs.docker.com/engine/install/debian/
+RUN mkdir -p /etc/apt/keyrings
+RUN  curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+RUN echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+RUN apt-get update -y
+RUN apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+
+## Install Serverless Tools
 COPY . .
 
 RUN gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.9.0)
+    serverless-tools (0.10.0)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3
@@ -16,7 +16,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.667.0)
+    aws-partitions (1.668.0)
     aws-sdk-core (3.168.2)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
@@ -25,7 +25,7 @@ GEM
     aws-sdk-ecr (1.57.0)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-kms (1.59.0)
+    aws-sdk-kms (1.60.0)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-lambda (1.88.0)
@@ -48,12 +48,12 @@ GEM
     faraday-net_http (3.0.2)
     gli (2.21.0)
     hashie (5.0.0)
-    jmespath (1.6.1)
+    jmespath (1.6.2)
     json (2.6.2)
     minitest (5.16.3)
     mocha (1.16.0)
     multipart-post (2.2.3)
-    octokit (6.0.0)
+    octokit (6.0.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     parallel (1.22.1)
@@ -110,4 +110,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   2.3.6
+   2.3.25

--- a/lib/serverless-tools/deployer/ecr_pusher.rb
+++ b/lib/serverless-tools/deployer/ecr_pusher.rb
@@ -11,6 +11,7 @@ module ServerlessTools
 
       def push(local_image_name:)
         system("docker tag #{local_image_name} #{tagged_image_uri}")
+        system("aws ecr get-login-password | docker login --username AWS --password-stdin #{repository_uri}")
         system("docker push #{tagged_image_uri}")
         asset
       end

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,3 +1,3 @@
 module ServerlessTools
-  VERSION = "0.9.0"
+  VERSION = "0.10.0"
 end

--- a/test/deployer/ecr_pusher_test.rb
+++ b/test/deployer/ecr_pusher_test.rb
@@ -30,6 +30,9 @@ module ServerlessTools::Deployer
           "docker tag #{local_image_name} #{registry_uri}/#{repo}:#{short_sha}"
         )
         subject.expects(:system).with(
+          "aws ecr get-login-password | docker login --username AWS --password-stdin #{registry_uri}/#{repo}"
+        )
+        subject.expects(:system).with(
           "docker push #{registry_uri}/#{repo}:#{short_sha}"
         )
 


### PR DESCRIPTION
closes https://github.com/fac/serverless-tools/issues/27

Docker support has always been limited to running serverless tools locally. This change updates the Dockerfile (which can be used locally) or more commonly as a Github Action. The image now supports building and pushing Docker based functions, as well as the other runtimes (Python 3.9, Ruby2.7).

This super seeds #64 and is less disruptive to downstream users.

Example of running build and deploy for a Docker based image: https://github.com/fac/data-lake-etl-python/actions/runs/3583315003/jobs/6028599518