### PR TITLE
Fix notifier for prod deployments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.10.0)
+    serverless-tools (0.11.0)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3
@@ -16,8 +16,8 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.668.0)
-    aws-sdk-core (3.168.2)
+    aws-partitions (1.672.0)
+    aws-sdk-core (3.168.3)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.5)
@@ -31,7 +31,7 @@ GEM
     aws-sdk-lambda (1.88.0)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.117.1)
+    aws-sdk-s3 (1.117.2)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.4)

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,3 +1,3 @@
 module ServerlessTools
-  VERSION = "0.10.0"
+  VERSION = "0.11.0"
 end

--- a/test/notifier/deployment_status_message_test.rb
+++ b/test/notifier/deployment_status_message_test.rb
@@ -43,28 +43,21 @@ module ServerlessTools::Notifier
               "html_url" => "https://github.com/fac/repo-name/actions/runs/3534407323",
               "run_attempt" => 1,
               "run_number" => 643,
+              "head_branch" => "branch-name",
               "head_sha" => sha,
               "pull_requests" => [
                 {
-                  "head" => {"ref" => "branch-name"},
                   "number" => 182,
                 }
               ],
               "head_commit" => {
+                "message" => "Commit message",
                 "author" => {
                   "name" => "Terry Pratchett"
                 }
               },
               "repository" => {
                 "html_url" => "https://github.com/fac/repo-name"
-              }
-            })
-
-          mock_git_client
-            .expects(:commit).with(repo_name, sha)
-            .returns({
-              "commit" => {
-                "message" => "Commit message"
               }
             })
         end
@@ -85,6 +78,37 @@ module ServerlessTools::Notifier
           expected = "❌ *FAILED* #{deploy_info}"
 
           assert_equal(subject.text_for_status("failure"), expected)
+        end
+      end
+
+      describe "when pull request info is missing" do
+        before do
+          mock_git_client
+            .expects(:workflow_run).with(repo_name, run_id)
+            .returns({
+              "html_url" => "https://github.com/fac/repo-name/actions/runs/3534407323",
+              "run_attempt" => 1,
+              "run_number" => 643,
+              "head_branch" => "branch-name",
+              "display_title" => "Commit message (#182)",
+              "head_sha" => sha,
+              "pull_requests" => [],
+              "head_commit" => {
+                "message" => "Commit message",
+                "author" => {
+                  "name" => "Terry Pratchett"
+                }
+              },
+              "repository" => {
+                "html_url" => "https://github.com/fac/repo-name"
+              }
+            })
+        end
+
+        it "still includes all the expected details in the message" do
+          expected = "🏗️ *DEPLOYING* #{deploy_info}"
+
+          assert_equal(subject.text_for_status("start"), expected)
         end
       end
     end


### PR DESCRIPTION
* get the branch name from the `head_branch` attribute
* get the PR number from the run's display title if otherwise missing
* get the commit message from the `head commit`