### PR TITLE
Increase timeout for Lambda to update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.11.0)
+    serverless-tools (0.11.1)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3

--- a/lib/serverless-tools/deployer/lambda_updater.rb
+++ b/lib/serverless-tools/deployer/lambda_updater.rb
@@ -15,7 +15,7 @@ module ServerlessTools
 
         client.wait_until(:function_updated,
           { function_name: response[:function_name] },
-          { max_attempts: 10, delay: 3 }
+          { max_attempts: 40, delay: 3 }
         )
 
         options

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,3 +1,3 @@
 module ServerlessTools
-  VERSION = "0.11.0"
+  VERSION = "0.11.1"
 end

--- a/test/deployer/lambda_updater_test.rb
+++ b/test/deployer/lambda_updater_test.rb
@@ -45,7 +45,7 @@ module ServerlessTools::Deployer
       lambda_client.expects(:wait_until).with(
         :function_updated,
         { function_name: function_name },
-        { max_attempts: 10, delay: 3 }
+        { max_attempts: 40, delay: 3 }
       ).returns(wait_response)
     end
 


### PR DESCRIPTION
30 seconds is quite low, we may as well wait for 2 minutes before
deciding something's gone wrong.

The main thing to go wrong at the Lambda update stage would be missing
permissions so generally only when initially setting up, after things
are set up there's minimal benefit to having a low timeout.

This could be configurable but I'd still be more forgiving as a default
value to avoid confusion on someone hitting this as soon as they start
using serverless-tools and getting confused (I'm talking from experience
here).
