### PR TITLE
Trigger the GHCR push workflow from freeagent-gem.yml 

### DIFF
--- a/.github/workflows/freeagent-gem.yml
+++ b/.github/workflows/freeagent-gem.yml
@@ -66,6 +66,7 @@ jobs:
     name: Trigger container push to GHCR
     runs-on: ubuntu-latest
     needs: release
+    if: ${{needs.release.outputs.version}}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/freeagent-gem.yml
+++ b/.github/workflows/freeagent-gem.yml
@@ -29,30 +29,44 @@ jobs:
     name: Gem / Release
     needs: test # Only release IF the tests pass
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.release-gem.outputs.pushed-version }}
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: ruby/setup-ruby@v1
-      with:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
           bundler-cache: true
-    - uses: fac/ruby-gem-setup-credentials-action@v2
-      with:
-        token: ${{ secrets.github_token }}
+      - uses: fac/ruby-gem-setup-credentials-action@v2
+        with:
+          token: ${{ secrets.github_token }}
 
-    - name: Build Gem
-      run: bundle exec rake build
+      - name: Build Gem
+        run: bundle exec rake build
 
-    # Release production gem version from default branch
-    - name: Release Gem
-      if:   ${{ github.ref == 'refs/heads/main' }}
-      uses: fac/ruby-gem-push-action@v2
-      with:
-        key: github
+      # Release production gem version from default branch
+      - name: Release Gem
+        id: release-gem
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: fac/ruby-gem-push-action@v2
+        with:
+          key: github
 
-    # PR branch builds will release pre-release gems
-    - name: Pre-Release Gem
-      if:   ${{ github.ref != 'refs/heads/main' }}
-      uses: fac/ruby-gem-push-action@v2
-      with:
-        key: github
-        pre-release: true
+      # PR branch builds will release pre-release gems
+      - name: Pre-Release Gem
+        if: ${{ github.ref != 'refs/heads/main' }}
+        uses: fac/ruby-gem-push-action@v2
+        with:
+          key: github
+          pre-release: true
+  # Trigger the "Push to Github Container Registry" workflow manually,
+  # since events triggered by the GITHUB_TOKEN don’t trigger other workflows:
+  # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+  trigger-ghcr-push:
+    name: Trigger container push to GHCR
+    runs-on: ubuntu-latest
+    needs: release
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - run: gh workflow --repo ${{ github.repository }} run "Push to Github Container Registry" -f version=${{needs.release.outputs.version}}

--- a/.github/workflows/push-to-ghcr.yml
+++ b/.github/workflows/push-to-ghcr.yml
@@ -1,29 +1,24 @@
 name: Push to Github Container Registry
 
 on:
-  push:
-    tags:
-      - "v*"
-  issue_comment:
-    types: [created]
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        required: true
+        description: The value of the release version tag, e.g. v0.12.0
 env:
   IMAGE_NAME: serverless-tools-gha
 
 jobs:
   push:
     runs-on: ubuntu-latest
-    if: (github.event.issue.pull_request && contains(github.event.comment.body, 'container push')) || ${{ startsWith(github.ref, 'refs/tags/v') }}
     permissions:
       packages: write
       contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Checkout Pull Request
-        if: github.event.issue
-        run: hub pr checkout ${{ github.event.issue.number }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build image
         run: |
           docker build . \
@@ -38,18 +33,7 @@ jobs:
         run: |
           IMAGE_ID=ghcr.io/fac/"$IMAGE_NAME"
 
-          comment="${{ github.event.comment }}"
-          ref="${{ github.ref }}"
-
-          # For issue comments, use a short sha as the version
-          if [ -n "$comment" ]
-          then
-            VERSION="$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }} -q .head.sha | cut -c-7)"
-          # For tagged releases, use the version tag instead
-          elif [[ "$ref" == "refs/tags/"* ]]
-          then
-            VERSION="${ref/refs\/tags\//}"
-          fi
+          VERSION="${{ github.event.inputs.version }}"
 
           echo IMAGE_ID="$IMAGE_ID"
           echo VERSION="$VERSION"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.12.0)
+    serverless-tools (0.12.1)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,6 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.12.0"
+  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.12.1"
   args:
     - ${{ inputs.command }}

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,3 +1,3 @@
 module ServerlessTools
-  VERSION = "0.12.0"
+  VERSION = "0.12.1"
 end


### PR DESCRIPTION
Since events triggered by the GITHUB_TOKEN don’t trigger other workflows,
the "Push to Github Container Registry" workflow currently isn't being
triggered when a new version tag is pushed to the repository once the gem
gets released. Instead, we can trigger the workflow explicitly.

https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow