### PR TITLE
Bump serverless-tools to 0.12.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.12.2)
+    serverless-tools (0.12.3)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3
@@ -110,4 +110,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   2.3.25
+   2.4.7

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,3 +1,3 @@
 module ServerlessTools
-  VERSION = "0.12.2"
+  VERSION = "0.12.3"
 end


### PR DESCRIPTION
Release the various AWS and Rubocop gem upgrades from the last month

* [Bump aws-sdk-s3 from 1.119.0 to 1.119.1](https://github.com/fac/serverless-tools/commit/9d2ba193a764acedc8cc2cdf14456065b45f1dfc)
* [Bump rubocop from 1.44.1 to 1.45.1](https://github.com/fac/serverless-tools/commit/430fcbdab2600922158f4522bad71fa58af2a5b0)
* [Bump aws-sdk-s3 from 1.118.0 to 1.119.0](https://github.com/fac/serverless-tools/commit/115054c96fafa76b51c8245bb7b1a90d4a078ac1)
* [Bump aws-sdk-lambda from 1.90.0 to 1.91.0](https://github.com/fac/serverless-tools/commit/5ab66cfab5e5eb5add9c06765d30a5d6ba1f3431)
* [Bump rubocop from 1.43.0 to 1.44.1](https://github.com/fac/serverless-tools/commit/a3d50bd997daa859e88918c7f5774d731223c20f)
* [Bump aws-sdk-ecr from 1.57.0 to 1.58.0](https://github.com/fac/serverless-tools/commit/c572c823528864fcb874a97f639eac733f43d44d)
* [Bump aws-sdk-lambda from 1.89.0 to 1.90.0](https://github.com/fac/serverless-tools/commit/dfba1fc4e2b2aba5d18e5bd59fc42a9e2b9380a5)
* [Bump aws-sdk-s3 from 1.117.2 to 1.118.0](https://github.com/fac/serverless-tools/commit/75a21b65817dda64b5c70fcbd42af0bcb91752bc)