### PR TITLE
Raise errors fom system calls.

### DIFF
--- a/lib/serverless-tools.rb
+++ b/lib/serverless-tools.rb
@@ -1,4 +1,4 @@
 require "serverless-tools/version"
 require "serverless-tools/cli"
 
-module ServerlessTools; end
+module ServerlessTools;end

--- a/lib/serverless-tools/deployer/docker_builder.rb
+++ b/lib/serverless-tools/deployer/docker_builder.rb
@@ -1,14 +1,18 @@
 # frozen_string_literal: true
 
+require_relative "./system_call"
+
 module ServerlessTools
   module Deployer
     class DockerBuilder
+      include SystemCall
+
       def initialize(config:)
         @config = config
       end
 
       def build
-        system("docker build . -f #{config.dockerfile} -t #{local_image_name} #{platform}".rstrip)
+        system_call "docker build . -f #{config.dockerfile} -t #{local_image_name} #{platform}".rstrip
       end
 
       def output

--- a/lib/serverless-tools/deployer/ecr_pusher.rb
+++ b/lib/serverless-tools/deployer/ecr_pusher.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative "./system_call"
+
 module ServerlessTools
   module Deployer
     class EcrPusher
+      include SystemCall
+
       def initialize(client:, git:, config:)
         @client = client
         @git = git
@@ -10,9 +14,9 @@ module ServerlessTools
       end
 
       def push(local_image_name:)
-        system("docker tag #{local_image_name} #{tagged_image_uri}")
-        system("aws ecr get-login-password | docker login --username AWS --password-stdin #{repository_uri}")
-        system("docker push #{tagged_image_uri}")
+        system_call "docker tag #{local_image_name} #{tagged_image_uri}"
+        system_call "aws ecr get-login-password | docker login --username AWS --password-stdin #{repository_uri}"
+        system_call "docker push #{tagged_image_uri}"
         asset
       end
 

--- a/lib/serverless-tools/deployer/python_builder.rb
+++ b/lib/serverless-tools/deployer/python_builder.rb
@@ -1,21 +1,25 @@
 # frozen_string_literal: true
 require "fileutils"
 
+require_relative "./system_call"
+
 module ServerlessTools
   module Deployer
     class PythonBuilder
+      include SystemCall
+
       def initialize(config:)
         @config = config
       end
       # Run three commands to build the python bundle for Lambda
       def build
         # Poetry does not have an option to install dependencies to a specified target folder.
-        `poetry build`
+        system_call "poetry build"
         # Workaround is installing them using pip to specified "lambda-package" target directory
-        `python3 -m pip install -t lambda-package dist/*.whl`
+        system_call "python3 -m pip install -t lambda-package dist/*.whl"
         # Zipping lambda-package folder with the handler file in a zip as required by AWS
-        `zip -jr "#{local_filename}" #{config.handler_file}`
-        `cd lambda-package && zip -r "../#{local_filename}" ./*`
+        system_call "zip -jr \"#{local_filename}\" #{config.handler_file}"
+        system_call "cd lambda-package && zip -r \"../#{local_filename}\" ./*"
         # Clean up
         clean
       end

--- a/lib/serverless-tools/deployer/ruby_builder.rb
+++ b/lib/serverless-tools/deployer/ruby_builder.rb
@@ -1,15 +1,19 @@
 # frozen_string_literal: true
 
+require_relative "./system_call"
+
 module ServerlessTools
   module Deployer
     class RubyBuilder
+      include SystemCall
+
       def initialize(config:)
         @config = config
       end
 
       def build
-        `bundle`
-        `zip -r "#{local_filename}" #{config.handler_file} lib vendor/`
+        system_call "bundle"
+        system_call "zip -r \"#{local_filename}\" #{config.handler_file} lib vendor/"
       end
 
       def output

--- a/lib/serverless-tools/deployer/system_call.rb
+++ b/lib/serverless-tools/deployer/system_call.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module ServerlessTools
+  module Deployer
+    module SystemCall
+      # system_call wraps the Kernel system method
+      # to ensure we're consistently calling out
+      # to the system and raising errors.
+
+      # The deployer calls out to the system in a
+      # number of places and we want to ensure any
+      # errors by the sub proceess are raised accordingly.
+      def system_call(cmd)
+        system(cmd, exception: true)
+      end
+    end
+  end
+end

--- a/test/deployer/docker_builder_test.rb
+++ b/test/deployer/docker_builder_test.rb
@@ -12,7 +12,7 @@ module ServerlessTools::Deployer
 
     describe "#build" do
       it "builds the Docker image" do
-        subject.expects(:system).with(
+        subject.expects(:system_call).with(
           "docker build . -f Dockerfile -t function_one_ecr_repo:latest"
         )
         subject.build
@@ -28,7 +28,7 @@ module ServerlessTools::Deployer
           )
         }
         it "builds the image for the specific platform" do
-          subject.expects(:system).with(
+          subject.expects(:system_call).with(
             "docker build . -f Dockerfile -t function_one_ecr_repo:latest --platform linux/amd64"
           )
           subject.build

--- a/test/deployer/ecr_pusher_test.rb
+++ b/test/deployer/ecr_pusher_test.rb
@@ -26,13 +26,13 @@ module ServerlessTools::Deployer
 
     describe "#push" do
       it "uploads the image and returns the uploaded configuration" do
-        subject.expects(:system).with(
+        subject.expects(:system_call).with(
           "docker tag #{local_image_name} #{registry_uri}/#{repo}:#{short_sha}"
         )
-        subject.expects(:system).with(
+        subject.expects(:system_call).with(
           "aws ecr get-login-password | docker login --username AWS --password-stdin #{registry_uri}/#{repo}"
         )
-        subject.expects(:system).with(
+        subject.expects(:system_call).with(
           "docker push #{registry_uri}/#{repo}:#{short_sha}"
         )
 

--- a/test/deployer/python_builder_test.rb
+++ b/test/deployer/python_builder_test.rb
@@ -8,20 +8,16 @@ module ServerlessTools::Deployer
     let(:config) { FunctionConfig.new(name: "function_one", handler_file: "handler_file") }
     let(:subject) { PythonBuilder.new(config: config) }
 
-    def assert_file_exists?(exists = true)
-      assert_equal(File.exist?(subject.local_filename), exists)
-    end
-
     describe "#build" do
       it "creates a zip file for the Python code" do
-        assert_file_exists?(false)
+
+        subject.expects(:system_call).with("poetry build")
+        subject.expects(:system_call).with("python3 -m pip install -t lambda-package dist/*.whl")
+        subject.expects(:system_call).with("zip -jr \"function_one.zip\" handler_file")
+        subject.expects(:system_call).with("cd lambda-package && zip -r \"../function_one.zip\" ./*")
 
         subject.build
 
-        assert_file_exists?(true)
-
-        # Clean up files and directories created by Python deployer build method
-        File.delete(subject.local_filename)
       end
 
       describe "#local_filename" do

--- a/test/deployer/ruby_builder_test.rb
+++ b/test/deployer/ruby_builder_test.rb
@@ -8,19 +8,13 @@ module ServerlessTools::Deployer
     let(:config) { FunctionConfig.new(name: "function_one", handler_file: "handler_file") }
     let(:subject) { RubyBuilder.new(config: config) }
 
-    def assert_file_exists?(exists = true)
-      assert_equal(File.exist?(subject.local_filename), exists)
-    end
-
     describe "#build" do
       it "creates a zip file for the ruby code" do
-        assert_file_exists?(false)
+        subject.expects(:system_call).with("bundle")
+        subject.expects(:system_call).with("zip -r \"function_one.zip\" handler_file lib vendor/")
 
         subject.build
 
-        assert_file_exists?(true)
-
-        File.delete(subject.local_filename)
       end
 
       describe "#local_filename" do


### PR DESCRIPTION
The deployment command relies heavily on calling out to subprocesses for building and pushing assets. However, we executed these processes in different ways and did not raise exceptions if they failed. Therefore it was easy for deployments to appear successful when they should have failed.

This isn't the entire story, as the updates to the Lambda function are also caught to enable commenting on PRs. This will be addressed seperately.