### PR TITLE
Raise errors from lambda updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.12.3)
+    serverless-tools (0.13.0)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3

--- a/lib/serverless-tools/deployer.rb
+++ b/lib/serverless-tools/deployer.rb
@@ -25,10 +25,35 @@ module ServerlessTools
     def self.run_action(action:, deployers:)
       deployers.each do |deployer|
         deployer.send(action)
+
+        log_github_output(deployer)
       rescue NoMethodError, ArgumentError => e
         puts "Given action not known! Got #{action}, expected one of [build, push, update, deploy]"
+        log_github_error(deployer)
+        raise e
+      rescue StandardError => e
+        log_github_error(deployer)
         raise e
       end
+    end
+
+    # When we're running inside a Github Action and its possible to log the output
+    # we should. This opens up the possibility to report on the actions from other
+    # steps in the job. However, we don't want to perform this if we're not in Github.
+    def self.running_in_github?
+      !ENV.fetch("GITHUB_ENV", "").empty?
+    end
+
+    # We don't use the system_command wrapper here as we don't care if this fails. i.e.
+    # we don't want the logging of a successful deployment fail a deployment workflow.
+    def self.log_github_output(deployer)
+      return unless running_in_github?
+      system("echo \"#{deployer.config.name}_status=Success\" >> \"$GITHUB_OUTPUT\"")
+    end
+
+    def self.log_github_error(deployer)
+      return unless running_in_github?
+      system("echo \"#{deployer.config.name}_status=Failed\" >> \"$GITHUB_OUTPUT\"")
     end
   end
 end

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,3 +1,3 @@
 module ServerlessTools
-  VERSION = "0.12.3"
+  VERSION = "0.13.0"
 end

--- a/test/deployer_test.rb
+++ b/test/deployer_test.rb
@@ -21,12 +21,56 @@ module ServerlessTools
         Deployer::FunctionDeployer.stubs(:create_for_function).with(config: lambda_config,
           options: options).returns(deployer)
 
-        config.expects(:lambda_config).with(function_name: function).returns(lambda_config)
-        deployer.expects(:build)
+        Deployer.stubs(:system)
+        config.stubs(:lambda_config).with(function_name: function).returns(lambda_config)
+
+        lambda_config.stubs(:name).returns(function)
+        deployer.stubs(:config).returns(lambda_config)
+        deployer.stubs(:build)
+
+        ENV.stubs(:fetch).with("GITHUB_ENV", "").returns("ENV VAR SET BY GITHUB")
       end
 
       it "sends the action to the created deployer" do
         Deployer.deploy(action: "build", function: function, options: options)
+      end
+
+      describe "$GITHUB_OUTPUT" do
+        describe "when the function is updated successfully" do
+          it "outputs the correct status" do
+            Deployer.expects(:system).with("echo \"#{function}_status=Success\" >> \"$GITHUB_OUTPUT\"")
+            Deployer.deploy(action: "build", function: function, options: options)
+          end
+        end
+
+        describe "when the function errors" do
+          before do
+            deployer.stubs(:update).raises(StandardError)
+          end
+
+          it "captures the error output to send to Github" do
+            Deployer.expects(:system).with("echo \"#{function}_status=Failed\" >> \"$GITHUB_OUTPUT\"")
+            assert_raises StandardError do
+              Deployer.deploy(action: "update", function: function, options: options)
+            end
+          end
+        end
+
+        describe "when the action does not exist" do
+          before do
+            deployer.stubs(:no_method).raises(NoMethodError)
+          end
+          it "captures the error output to send to Github" do
+            Deployer.expects(:system).with("echo \"#{function}_status=Failed\" >> \"$GITHUB_OUTPUT\"")
+            Deployer.expects(:puts).with(
+              "Given action not known! Got no_method, expected one of [build, push, update, deploy]"
+            )
+
+            assert_raises NoMethodError do
+              Deployer.deploy(action: "no_method", function: function, options: options)
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Resolves https://github.com/fac/serverless-tools/issues/48

Follow up to https://github.com/fac/serverless-tools/pull/113

This PR follows the previous to ensure that the Lambda function update error will bubble up with a non-zero error code. We still capture the log, but now the user will get an error trace and the correct exit code (1) for errors.

This will halt the execution of the Github Job which is desired in most cases. Elevates the logging to Github to a higher level, where it is better suited as it is an orchestration task, not a specific deployment concern. I think this elevation could be more useful in the future, if we want to consider better github comments, or co-ordinate rollbacks etc.

There's a slight change of functionality here and a bit of a braking change for the staging deploy workflow. Users will be required to update their workflow to continue receiving comments on staging deploys when the job fails, the job will now also 'fail fast', i.e. if it fails on the first function it will not attempt to deploy the next function. I think this is better as we want to get to the problem as soon as possible.