### PR TITLE
Release v0.13.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.13.0)
+    serverless-tools (0.13.1)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,6 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.12.1"
+  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.13.1"
   args:
     - ${{ inputs.command }}

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,3 +1,5 @@
 module ServerlessTools
-  VERSION = "0.13.0"
+  # When updating the version, also update the verion specified in the image tag
+  # of the action.yml.
+  VERSION = "0.13.1"
 end


### PR DESCRIPTION
In the previous PR I forgot to bump the version up in the action.yml so I'm doing that here. There's a little risk in that the previous few versions haven't been rolled out but people _think_ they've been updating to the latest version. In almost all previous versions the changes have been gem updates. 