### PR TITLE
Fix git client CVE-2022-24765 updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.13.1)
+    serverless-tools (0.13.2)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3

--- a/README.md
+++ b/README.md
@@ -210,3 +210,19 @@ In order to create a new version:
 - Use the same version number under `runs`>`image` in `action.yml`
 - Once your PR is merged, the RubyGem and Container version will be pushed to the Github Container Registry
 - The Github Actions Workflow that published the gem will push a tag for the new version to the repo. You're encouraged to [publish a release](https://github.com/fac/serverless-tools/releases) associated with that tag once it's created.
+
+### Testing Changes
+
+There are various challenges to testing serverless tools as a GitHub Action locally. While running the image locally can provide some confidence, the nature of not controlling the GitHub Runner or how it mounts and runs the container can result in edge cases and errors.
+
+One way to test changes prior to release is to create a pull request with your changes and update the `image` argument value in the `action.yml` file to "Dockerfile". Then, reference your branch where serverless tools are being used. For example:
+
+```
+- name: build assets
+        uses: fac/serverless-tools@your-branch
+        with:
+          command: deploy build
+
+```
+
+Through this process, changes can be tested before merging. Be sure to update the `image` value in `action.yml` to the version you will release once testing is complete.

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,6 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.13.1"
+  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.13.2"
   args:
     - ${{ inputs.command }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,4 +3,10 @@
 # `$*` expands the `args` supplied in an `array` individually
 # or splits `args` in a string separated by whitespace.
 echo ">>> Running serverless-tools"
+
+# The following config is required to use the git
+# client within Github Actions. For more information,
+# see here: https://github.com/fac/serverless-tools/issues/120
+git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
 sh -c "serverless-tools $*"

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,5 +1,5 @@
 module ServerlessTools
   # When updating the version, also update the verion specified in the image tag
   # of the action.yml.
-  VERSION = "0.13.1"
+  VERSION = "0.13.2"
 end


### PR DESCRIPTION
The following changes are required to resolve https://github.com/fac/serverless-tools/issues/120

Ultimately, the issue stems from an updated git client containing a security fix to prevent prevent parent directories manipulating child directories owned by others. As Serverless Tools runs in a container on Github Runners with different owners, we were unable to use the Git Client.

The fix for this is to specify that the directory is safe. For more information see the issues, and linked issues within.

Examples of using the changes:
https://github.com/fac/data-lake-etl-python/actions/runs/4677070104/jobs/8284231859

Examples of prior failing runs using the previous version:
https://github.com/fac/data-lake-etl-python/actions/runs/4668315202/jobs/8283232437
