### PR TITLE
Bumping serverless tools version: 0.13.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.13.3)
+    serverless-tools (0.13.4)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,6 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.13.3"
+  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.13.4"
   args:
     - ${{ inputs.command }}

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,5 +1,5 @@
 module ServerlessTools
   # When updating the version, also update the verion specified in the image tag
   # of the action.yml.
-  VERSION = "0.13.3"
+  VERSION = "0.13.4"
 end


### PR DESCRIPTION
# What
Releasing 0.13.4:
- #125
- #126
  - Feature - Provides support for "Snow" Storage class.
- #127
  - Feature - Add Python 3.10 (python3.10) support to AWS Lambda