### PR TITLE
Improve the deployment message published by the Notifier tool

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.13.4)
+    serverless-tools (0.14.0)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Example usage in a Github Actions workflow:
           SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
           command: notify start ${{ github.run_id }} --repo=${{github.repository}} --channel=ABCDEFGH
+        continue-on-error: true
 ```
 
 ## Image

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,6 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.13.4"
+  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.14.0"
   args:
     - ${{ inputs.command }}

--- a/lib/serverless-tools/notifier/deployment_status_message.rb
+++ b/lib/serverless-tools/notifier/deployment_status_message.rb
@@ -59,8 +59,11 @@ module ServerlessTools
         run_url = "#{workflow_run_info["html_url"]}/attempts/#{workflow_run_info["run_attempt"]}"
         head_branch = workflow_run_info["head_branch"]
         run_number = workflow_run_info["run_number"]
+
+        delimiters = [" ", /(?=[A-Z])/]
         slack_name = workflow_run_info["head_commit"]["author"]["name"]
-                      .split(" ")
+                      .gsub( /\d+/,"")
+                      .split(Regexp.union(delimiters))
                       .map(&:downcase)
                       .join(".")
                       .delete("'")

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,5 +1,5 @@
 module ServerlessTools
   # When updating the version, also update the verion specified in the image tag
   # of the action.yml.
-  VERSION = "0.13.4"
+  VERSION = "0.14.0"
 end

--- a/test/notifier/deployment_status_message_test.rb
+++ b/test/notifier/deployment_status_message_test.rb
@@ -140,6 +140,36 @@ module ServerlessTools::Notifier
           end
         end
       end
+
+      describe "when author name follows unusual formatting" do
+        before do
+          mock_git_client
+            .expects(:workflow_run).with(repo_name, run_id)
+            .returns({
+              "html_url" => "https://github.com/fac/repo-name/actions/runs/3534407323",
+              "run_attempt" => 1,
+              "run_number" => 643,
+              "head_branch" => "branch-name",
+              "pull_requests" => [],
+              "head_commit" => {
+                "id" => sha,
+                "message" => "Commit message (#182)",
+                "author" => {
+                  "name" => "TerryPratchett123"
+                }
+              },
+              "repository" => {
+                "html_url" => "https://github.com/fac/repo-name"
+              }
+            })
+        end
+
+        it "formats the name correctly for Slack" do
+          expected = "🏗️ *DEPLOYING* #{deploy_info}"
+
+          assert_equal(subject.text_for_status("start"), expected)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR implements a handful of improvements to how Slack deployment notifications get built in the Notifier tool: 

• **Problem**: tagging Slack users doesn't work if the person's Github name is formatted in an usual way (e.g. using PascalCase or including numbers)
<img width="588" alt="Screenshot 2023-05-03 at 15 47 56" src="https://user-images.githubusercontent.com/25990431/235952275-6a7167e9-bfac-4683-a1a4-f309693e08fa.png">

**Solution**: We're now stripping any numbers, and split the Github username on uppercase letters. 

• **Problem:** Slack notifications fail to be built if the PR number is missing from the workflow run's `display_title` (https://github.com/fac/serverless-tools/issues/107)

**Description:** When a PR is merged, the Github workflow run's information doesn't reference the PR directly (as it does, e.g. when pushing to the repository), but the PR number _should_ be included in the PR title. At present, we're trying to retrieve the PR number from the `display_title` attribute of the workflow's run info - however, this gets truncated for longer titles, and the notification fails to be built. 

**Solution:** It turns out that the `message` attribute of the `head_commit` always contains the PR's title and number when merging to main, and doesn't get truncated, so we can use that for Slack notifications instead. 

While making changes in this area, I've also made some tweaks so that:
a) if the head commit's message doesn't include the PR number, but we can get it elsewhere, it's added to the notification
b) for merge commits, we don't duplicate the PR number in brackets (see screenshot below for current behaviour)

<img width="516" alt="Screenshot 2023-05-03 at 15 37 08" src="https://user-images.githubusercontent.com/25990431/235949135-0efaed72-5ee4-4af0-b1a1-8edece6b6560.png">
c) if we fail to get the PR number at all, the notification will just include the head commit's message with no link to the PR (and won't break)

