### PR TITLE
Bump serverless-tools to 0.14.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.14.1)
+    serverless-tools (0.14.2)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,6 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.14.1"
+  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.14.2"
   args:
     - ${{ inputs.command }}

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,5 +1,5 @@
 module ServerlessTools
   # When updating the version, also update the verion specified in the image tag
   # of the action.yml.
-  VERSION = "0.14.1"
+  VERSION = "0.14.2"
 end


### PR DESCRIPTION
Dependency updates

- Bump test-unit from 3.5.7 to 3.5.8 #135
- Bump rubocop from 1.50.2 to 1.51.0 #134
- Bump thor from 1.2.1 to 1.2.2 #133
- Bump mocha from 1.16.0 to 1.16.1 #111