### PR TITLE
Bump serverless-tools to 0.14.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.14.6)
+    serverless-tools (0.14.7)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,6 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.14.6"
+  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.14.7"
   args:
     - ${{ inputs.command }}

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,5 +1,5 @@
 module ServerlessTools
   # When updating the version, also update the verion specified in the image tag
   # of the action.yml.
-  VERSION = "0.14.6"
+  VERSION = "0.14.7"
 end


### PR DESCRIPTION
Dependency Updates

- https://github.com/fac/serverless-tools/pull/158
- https://github.com/fac/serverless-tools/pull/157
- https://github.com/fac/serverless-tools/pull/152