### PR TITLE
Group up aws-adk dependency bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      aws-dependencies:
+        patterns:
+          - "aws-sdk-*"
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
Leverage the groups functionality to group up aws-sdk gem dumps into one PR