### PR TITLE
Bump serverless-tools to 0.14.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.14.8)
+    serverless-tools (0.14.9)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,6 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.14.8"
+  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.14.9"
   args:
     - ${{ inputs.command }}

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,5 +1,5 @@
 module ServerlessTools
   # When updating the version, also update the verion specified in the image tag
   # of the action.yml.
-  VERSION = "0.14.8"
+  VERSION = "0.14.9"
 end


### PR DESCRIPTION
* Depedency Updates
  * aws-sdk-lambda from 1.101.0 to 1.102.0
  * aws-sdk-s3 from 1.127.0 to 1.128.0
  * aws-sdk-ecr from 1.61.0 to 1.62.0 