### PR TITLE
Bump serverless-tools to 0.14.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.14.9)
+    serverless-tools (0.14.10)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,6 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.14.9"
+  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.14.10"
   args:
     - ${{ inputs.command }}

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,5 +1,5 @@
 module ServerlessTools
   # When updating the version, also update the verion specified in the image tag
   # of the action.yml.
-  VERSION = "0.14.9"
+  VERSION = "0.14.10"
 end


### PR DESCRIPTION
Dependency bumps

* Bump rubocop from 1.54.1 to 1.54.2 serverless-tools#171
* Bump the aws-dependencies group with 3 updates serverless-tools#170