### PR TITLE
Bump serverless-tools to 0.14.14

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.14.13)
+    serverless-tools (0.14.14)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,6 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.14.13"
+  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.14.14"
   args:
     - ${{ inputs.command }}

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,5 +1,5 @@
 module ServerlessTools
   # When updating the version, also update the verion specified in the image tag
   # of the action.yml.
-  VERSION = "0.14.13"
+  VERSION = "0.14.14"
 end


### PR DESCRIPTION
Bump Dependancies

* https://github.com/fac/serverless-tools/pull/195
* https://github.com/fac/serverless-tools/pull/194
* https://github.com/fac/serverless-tools/pull/192