### PR TITLE
Add logging for when an image can't be found in ECR.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.14.14)
+    serverless-tools (0.14.15)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,6 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.14.14"
+  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.14.15"
   args:
     - ${{ inputs.command }}

--- a/lib/serverless-tools/deployer/ecr_pusher.rb
+++ b/lib/serverless-tools/deployer/ecr_pusher.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "./system_call"
+require_relative "../logging"
 
 module ServerlessTools
   module Deployer
@@ -21,8 +22,12 @@ module ServerlessTools
       end
 
       def output
-        return {} unless image_tags.include?(tag)
-        asset
+        tags = image_tags
+        if tags.include?(tag)
+          return asset
+        end
+        Logging.logger.debug("Unable to find tag #{tag} in #{tags}")
+        {}
       end
 
       private

--- a/lib/serverless-tools/logging.rb
+++ b/lib/serverless-tools/logging.rb
@@ -1,0 +1,15 @@
+require "logger"
+
+module ServerlessTools
+  module Logging
+    class << self
+      def logger
+        return @logger if defined? @logger
+
+        @logger = Logger.new(STDOUT)
+        @logger.level = ENV["SERVERLESS_TOOLS_LOG_LEVEL"] || :info
+        @logger
+      end
+    end
+  end
+end

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,5 +1,5 @@
 module ServerlessTools
   # When updating the version, also update the verion specified in the image tag
   # of the action.yml.
-  VERSION = "0.14.14"
+  VERSION = "0.14.15"
 end

--- a/test/deployer/ecr_pusher_test.rb
+++ b/test/deployer/ecr_pusher_test.rb
@@ -52,12 +52,12 @@ module ServerlessTools::Deployer
         before do
           ecr.stub_responses(
             :describe_images,
-            { image_details: [{ image_tags: [] }] },
-            { image_details: [{ image_tags: [short_sha] }] }
+            { image_details: [{ image_tags: ["8910111"] }] }
           )
         end
 
         it "returns an empty hash" do
+          ServerlessTools::Logging.logger.expects(:debug).with("Unable to find tag 1234567 in [\"8910111\"]")
           assert_equal(subject.output, {})
         end
       end


### PR DESCRIPTION
We have had occassions when deploying when an image can not be found in ECR. However, when we deploy, we expect the image to be there. There are a number of reasons why this could be. We're adding the logging to test what the response is from ECR, and what tag we're trying to use. This should help narrow down the issue.


Example of usage (in runner): https://github.com/fac/data-lake-management/actions/runs/6199076798/job/16831244023
Example of usage (in workflow.yml):

```yml
      - name: Push Assets to ECR
        uses: fac/serverless-tools@add-logging-for-pushing-images
        with:
          command: deploy push data-lake-management_matillion_job_listener_v1
        env:
          SERVERLESS_TOOLS_LOG_LEVEL: "debug"
```
