### PR TITLE
Fix/intermittent docker deploy fails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.15.0)
+    serverless-tools (0.16.0)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,6 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.15.0"
+  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.16.0"
   args:
     - ${{ inputs.command }}

--- a/lib/serverless-tools/deployer/ecr_pusher.rb
+++ b/lib/serverless-tools/deployer/ecr_pusher.rb
@@ -41,6 +41,7 @@ module ServerlessTools
       def image_tags
         client.describe_images(
           repository_name: config.repo,
+          max_results: 1000,
           registry_id: config.registry_id
         ).image_details.flat_map(&:image_tags)
       end

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,5 +1,5 @@
 module ServerlessTools
   # When updating the version, also update the verion specified in the image tag
   # of the action.yml.
-  VERSION = "0.15.0"
+  VERSION = "0.16.0"
 end

--- a/test/deployer/ecr_pusher_test.rb
+++ b/test/deployer/ecr_pusher_test.rb
@@ -74,6 +74,7 @@ module ServerlessTools::Deployer
           assert_equal(subject.output, expected)
           assert_equal(ecr.api_requests.first[:params], {
             repository_name: repo,
+            max_results: 1000,
             registry_id: registry_id,
           })
         end


### PR DESCRIPTION
🐛  https://github.com/fac/data-platform/issues/1182

We occasionally hit a bug where we have too many images
in our repository and on deploy we can't find the correct image tag as
it is not included on the first page of the results.

Our ECR repositories are configured to retain 100 images, but there is
latency in the deletion of the old images so we can hit this.

As the repos are limited to 100, the simplest fix is to bump the
max results to 1000.

Tested on dev in the data-platform aws accounts and this works as intended

Log output:
```
dev serverless-tools deploy update deletion-pauldlm_company_data_finder_v1 --force -f dev_functions.yml 
D, [2023-10-25T16:29:34.800106 #73919] DEBUG -- : Number of tags 108
    ✅ Sucessfully updated
```