### PR TITLE
Bumping version number

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.17.11)
+    serverless-tools (0.17.12)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,6 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.17.11"
+  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.17.12"
   args:
     - ${{ inputs.command }}

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,5 +1,5 @@
 module ServerlessTools
   # When updating the version, also update the verion specified in the image tag
   # of the action.yml.
-  VERSION = "0.17.11"
+  VERSION = "0.17.12"
 end


### PR DESCRIPTION
# What
Version bumps have been missed for a few weeks, so this will likely have [a few more dependency bumps](https://github.com/fac/serverless-tools/compare/v0.17.11...main) than normal.