### PR TITLE
Release v0.17.13

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.17.12)
+    serverless-tools (0.17.13)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,6 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.17.12"
+  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.17.13"
   args:
     - ${{ inputs.command }}

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,5 +1,5 @@
 module ServerlessTools
   # When updating the version, also update the verion specified in the image tag
   # of the action.yml.
-  VERSION = "0.17.12"
+  VERSION = "0.17.13"
 end


### PR DESCRIPTION
Dependency Updates

[Bump the aws-dependencies group across 1 directory with 3 updates](https://github.com/fac/serverless-tools/commit/bfad4ad3f95b1d3838fe446efd240546583f8e2b)

[Bump octokit from 8.1.0 to 9.1.0](https://github.com/fac/serverless-tools/commit/474a6e6c3ae2a0250cfeedfab5325e3704a66ec6)

[Bump mocha from 2.3.0 to 2.4.0](https://github.com/fac/serverless-tools/commit/f5956c097698ac21a33251cb56c4acc39d29a538)
