### PR TITLE
Updating release guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,11 @@ To release your PR's changes:
 Once your PR is merged, the RubyGem and Container version will be pushed to the Github Container Registry
 
 The Github Actions Workflow that published the gem will push a tag for the new version to the repo. To publish it:
+
+> [!WARNING]
+> Ensure the gem and docker image have been released on your merge. Otherwise creating the release notes
+> will create a tag, causing the gem release to fail, and skip the docker image release.
+
 1. Open [the gem's list of releases](https://github.com/fac/serverless-tools/releases).
 1. Click on **Draft a new release**
 1. In the **Choose a tag** dropdown, select the tag for the gem version you just released


### PR DESCRIPTION
# What
The gem release step expects to create a tag for the new gem version. Manually doing the Release Notes and creating a tag before this action has completed will cause the release workflow to fail at the gem release step. This causes the docker image step to be skipped, resulting in:
- dependabot being aware of a new release
- the gem version being available
- no docker imaage for the release being available.

Dev-P are a bit strapped for time just now, so I'm documenting our way around the issue for now.

Dev-P Ticket:
- https://github.com/fac/dev-platform/issues/2283