### PR TITLE
Bumping to v0.17.21

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.17.19)
+    serverless-tools (0.17.21)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,6 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.17.19"
+  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.17.21"
   args:
     - ${{ inputs.command }}

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,5 +1,5 @@
 module ServerlessTools
   # When updating the version, also update the verion specified in the image tag
   # of the action.yml.
-  VERSION = "0.17.19"
+  VERSION = "0.17.21"
 end


### PR DESCRIPTION
# What
Resolving versioning issues:
- [v0.17.19](https://github.com/fac/serverless-tools/releases/tag/v0.17.19) was incorrectly released (no version bump, but created in GitHub Releases)
- [v0.17.20](https://github.com/fac/serverless-tools/releases/tag/v0.17.20) had it's version bumped but incorrectly to `v0.17.19`, marked correctly in GitHub Releases

Making a clean break here to release `v0.17.21` both as version and as GitHub Release