### PR TITLE
Bump serverless-tools to 0.18.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.17.23)
+    serverless-tools (0.18.0)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3
@@ -175,7 +175,7 @@ CHECKSUMS
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
   sawyer (0.9.2) sha256=fa3a72d62a4525517b18857ddb78926aab3424de0129be6772a8e2ba240e7aca
-  serverless-tools (0.17.23)
+  serverless-tools (0.18.0)
   slack-ruby-client (2.5.1) sha256=d7075c79e5a39fae4003ed5f786b258d2d7795c01b1a7a97684078bc3561c92d
   test-unit (3.6.7) sha256=c342bb9f7334ea84a361b43c20b063f405c0bf3c7dbe3ff38f61a91661d29221
   thor (1.3.2) sha256=eef0293b9e24158ccad7ab383ae83534b7ad4ed99c09f96f1a6b036550abbeda

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,6 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.17.23"
+  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.18.0"
   args:
     - ${{ inputs.command }}

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,5 +1,5 @@
 module ServerlessTools
   # When updating the version, also update the verion specified in the image tag
   # of the action.yml.
-  VERSION = "0.17.23"
+  VERSION = "0.18.0"
 end


### PR DESCRIPTION
# What
Bumping serverless-tools version:
- Updated Ruby version `3.4.1`
- Dependabot PRs