### PR TITLE
Revert poetry action to v3

### DIFF
--- a/.github/workflows/freeagent-gem.yml
+++ b/.github/workflows/freeagent-gem.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: "3.9"
       - name: Setup Poetry # Required for testing but not for building the gem.
-        uses: abatilo/actions-poetry@v4.0.0
+        uses: abatilo/actions-poetry@v3.0.2
         with:
           poetry-version: "1.1.13"
       - run: bundle install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           python-version: "3.9"
       - name: Setup Poetry
-        uses: abatilo/actions-poetry@v4.0.0
+        uses: abatilo/actions-poetry@v3.0.2
         with:
           poetry-version: "1.1.13"
       - run: bundle install


### PR DESCRIPTION
Version 4 of the abatilo/actions-poetry GH action is having issues with using the correct python environment causing all checks that use poetry to fail.

See abatilo/actions-poetry#85 & abatilo/actions-poetry@b8f6fe2