### PR TITLE
Bump serverless-tools to 0.19.18

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serverless-tools (0.19.17)
+    serverless-tools (0.19.18)
       aws-sdk-ecr
       aws-sdk-lambda
       aws-sdk-s3
@@ -182,7 +182,7 @@ CHECKSUMS
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
   sawyer (0.9.2) sha256=fa3a72d62a4525517b18857ddb78926aab3424de0129be6772a8e2ba240e7aca
-  serverless-tools (0.19.17)
+  serverless-tools (0.19.18)
   slack-ruby-client (3.0.0) sha256=e22d07e3b586018b38dcfb3b14af9542c6063bf6992bc0c4f2433d0b5b8a674a
   test-unit (3.7.0) sha256=2b5745498c848768e1774acb63e3806d3bb47e2943bd91cc9bf559b4c6d4faa1
   thor (1.4.0) sha256=8763e822ccb0f1d7bee88cde131b19a65606657b847cc7b7b4b82e772bcd8a3d

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,6 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.19.17"
+  image: "docker://ghcr.io/fac/serverless-tools-gha:v0.19.18"
   args:
     - ${{ inputs.command }}

--- a/lib/serverless-tools/version.rb
+++ b/lib/serverless-tools/version.rb
@@ -1,5 +1,5 @@
 module ServerlessTools
   # When updating the version, also update the verion specified in the image tag
   # of the action.yml.
-  VERSION = "0.19.17"
+  VERSION = "0.19.18"
 end


### PR DESCRIPTION
Releasing dependency updates
- #458
- #459
- #460